### PR TITLE
Rerun starvation logic on battleEndTurn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
       - image: circleci/node:current
     steps:
       - checkout
-      - run: npm run robot
+      - run: npm run robot && npm run test

--- a/modules/battle/src/battle/helpers/addStarvationToStep.ts
+++ b/modules/battle/src/battle/helpers/addStarvationToStep.ts
@@ -1,0 +1,18 @@
+import { AlgolStep } from "../../../../types";
+
+// Will mutate step endGame link with Starvation.
+// Used in .battleEndTurn and .hydrateStepInTurn
+export function addStarvationToStep(step: AlgolStep) {
+  const stepLinks = step.LINKS;
+  if (stepLinks.starvation) {
+    stepLinks.endGame = stepLinks.starvation.endGame;
+    stepLinks.endedBy = stepLinks.starvation.endedBy;
+    stepLinks.endMarks =
+      stepLinks.starvation.endMarks ||
+      Object.keys(step.UNITLAYERS.myunits || {});
+  } else {
+    stepLinks.endGame = "win";
+    stepLinks.endedBy = "starvation";
+    stepLinks.endMarks = Object.keys(step.UNITLAYERS.myunits || {});
+  }
+}

--- a/modules/battle/src/battle/helpers/battleEndTurn.ts
+++ b/modules/battle/src/battle/helpers/battleEndTurn.ts
@@ -4,6 +4,7 @@ import { battleEndGame } from "./battleEndGame";
 
 import { emptyAnim } from "../../../../common";
 import { battleTurnPath } from "./battleTurnPath";
+import { addStarvationToStep } from "./addStarvationToStep";
 
 export function battleEndTurn(game: AlgolGame, btl: AlgolBattle): AlgolBattle {
   const battle = {
@@ -13,8 +14,14 @@ export function battleEndTurn(game: AlgolGame, btl: AlgolBattle): AlgolBattle {
   const currentStep = battle.turn.steps[battle.state.currentStepId];
 
   if (currentStep.LINKS.endGame) return battleEndGame(battle);
-
   const nextTurn = endTurn(game, battle.turn, battle.state.currentStepId);
+  // Have to repeat starvation code from `.hydrateStepInTurn` here
+  // since it might not have been run if this turn was never fully
+  // hydrated because of performance short circuit
+  if (!nextTurn.canEnd) {
+    addStarvationToStep(currentStep);
+    return battleEndGame(battle);
+  }
   return {
     path: battle.path,
     turnNumber: nextTurn.steps.root.TURN,

--- a/modules/battle/src/battle/helpers/index.ts
+++ b/modules/battle/src/battle/helpers/index.ts
@@ -7,3 +7,4 @@ export * from "./getBattleInstruction";
 export * from "./battleTurnPath";
 export * from "./inflateBattleSave";
 export * from "./makeBattleSave";
+export * from "./addStarvationToStep";

--- a/modules/battle/src/battle/turn/helpers/hydrateStepInTurn.ts
+++ b/modules/battle/src/battle/turn/helpers/hydrateStepInTurn.ts
@@ -1,5 +1,6 @@
 import { AlgolTurn, AlgolGame } from "../../../../../types";
 import { tryToReachTurnEnd, newTurnFromRootStep } from "../helpers";
+import { addStarvationToStep } from "../../helpers";
 
 // removes dead links in this step
 export function hydrateStepInTurn(
@@ -35,17 +36,7 @@ export function hydrateStepInTurn(
       turn.nextTurns[stepId] = newTurn;
     } else {
       delete stepLinks.endTurn;
-      if (stepLinks.starvation) {
-        stepLinks.endGame = stepLinks.starvation.endGame;
-        stepLinks.endedBy = stepLinks.starvation.endedBy;
-        stepLinks.endMarks =
-          stepLinks.starvation.endMarks ||
-          Object.keys(step.UNITLAYERS.myunits || {});
-      } else {
-        stepLinks.endGame = "win";
-        stepLinks.endedBy = "starvation";
-        stepLinks.endMarks = Object.keys(step.UNITLAYERS.myunits || {});
-      }
+      addStarvationToStep(step);
       turn.gameEnds.win.push(stepId);
     }
   }


### PR DESCRIPTION
Fixes #30 

Starvation logic was sometimes broken because it was applied within `.hydrateTurn`. Performance configuration can cause hydration to be short-circuited, thus the starvation watermark was never added.

Fixed by also running starvation logic upon `.battleEndTurn`.