### PR TITLE
Make circleci run tests single threaded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
       - image: circleci/node:current
     steps:
       - checkout
-      - run: npm run robot && npm run test
+      - run: npm run robot && npm run test:ts && npx jest -w 1


### PR DESCRIPTION
CircleCI build now fail because it runs out of memory during the unit tests.
Attempt fix by running jest single-threaded.