### PR TITLE
Lift crumbs to gamepage component

### DIFF
--- a/modules/ui/src/components/BattleControls/BattleControls.tsx
+++ b/modules/ui/src/components/BattleControls/BattleControls.tsx
@@ -3,7 +3,6 @@ import React, { FunctionComponent, Fragment } from "react";
 import { AlgolContentAnon, AlgolMeta } from "../../../../types";
 
 import { Content } from "../Content";
-import { Breadcrumbs } from "../Breadcrumbs";
 
 export interface BattleControlsActions {
   undo: () => void;
@@ -19,9 +18,6 @@ type BattleControlsProps = {
   undo: string | null;
   actions: BattleControlsActions;
   haveHistory?: boolean;
-  turnNumber: number;
-  player: 0 | 1 | 2;
-  meta: AlgolMeta<string, string>;
 };
 
 export const BattleControls: FunctionComponent<BattleControlsProps> = ({
@@ -29,23 +25,9 @@ export const BattleControls: FunctionComponent<BattleControlsProps> = ({
   undo,
   actions,
   haveHistory,
-  turnNumber,
-  player,
-  meta,
 }) => {
-  const headline: AlgolContentAnon = {
-    line: [{ text: `turn ${turnNumber}, ` }, { player }],
-  };
   return (
     <Fragment>
-      <Breadcrumbs
-        actions={actions}
-        crumbs={[
-          { content: meta.name, onClick: actions.leaveBattle },
-          { content: "local" },
-          { content: <Content content={headline} /> },
-        ]}
-      />
       <Content content={instruction} actions={actions} />
       {undo && (
         <div>

--- a/modules/ui/src/components/BattleHistory/BattleHistory.tsx
+++ b/modules/ui/src/components/BattleHistory/BattleHistory.tsx
@@ -1,10 +1,9 @@
-import React, { FunctionComponent, Fragment } from "react";
-import { AlgolContentAnon, AlgolMeta } from "../../../../types";
+import React, { FunctionComponent } from "react";
+import { AlgolContentAnon } from "../../../../types";
 import { Content } from "../Content";
 import { Stepper } from "../Stepper";
 
 import css from "./BattleHistory.cssProxy";
-import { Breadcrumbs } from "../Breadcrumbs";
 
 interface BattleHistoryActions {
   toFrame: (frame: number) => void;
@@ -19,31 +18,20 @@ type BattleHistoryProps = {
   frameCount: number;
   actions: BattleHistoryActions;
   battleFinished: boolean;
-  meta: AlgolMeta<string, string>;
 };
 
 export const BattleHistory: FunctionComponent<BattleHistoryProps> = props => {
-  const { content, frame, frameCount, actions, battleFinished, meta } = props;
+  const { content, frame, frameCount, actions, battleFinished } = props;
   return (
-    <Fragment>
-      <Breadcrumbs
-        actions={actions}
-        crumbs={[
-          { content: meta.name, onClick: actions.leaveBattle },
-          { content: "local" },
-          { content: battleFinished ? "finished" : "history" },
-        ]}
-      />
-      <div className={css.battleHistoryContainer}>
-        <Stepper max={frameCount} current={frame} onChange={actions.toFrame} />
-        <Content content={content} />
-        <br />
-        {battleFinished ? (
-          <button onClick={actions.leaveBattle}>Leave battle</button>
-        ) : (
-          <button onClick={actions.leaveHistory}>Back to battle</button>
-        )}
-      </div>
-    </Fragment>
+    <div className={css.battleHistoryContainer}>
+      <Stepper max={frameCount} current={frame} onChange={actions.toFrame} />
+      <Content content={content} />
+      <br />
+      {battleFinished ? (
+        <button onClick={actions.leaveBattle}>Leave battle</button>
+      ) : (
+        <button onClick={actions.leaveHistory}>Back to battle</button>
+      )}
+    </div>
   );
 };

--- a/modules/ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/modules/ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -4,7 +4,7 @@ import css from "./Breadcrumbs.cssProxy";
 
 const noop = () => {};
 
-type Crumb = {
+export type Crumb = {
   content: ReactNode;
   onClick?: () => void;
 };

--- a/modules/ui/src/components/GameLanding/GameLanding.tsx
+++ b/modules/ui/src/components/GameLanding/GameLanding.tsx
@@ -15,7 +15,6 @@ import {
 } from "../../../../types";
 import { getSessionList } from "../../../../local/src";
 import { SessionList } from "../SessionList";
-import { Breadcrumbs } from "../Breadcrumbs";
 
 export interface GameLandingActions {
   new: () => void;
@@ -57,7 +56,6 @@ export const GameLanding: FunctionComponent<GameLandingProps> = props => {
   );
   return (
     <Fragment>
-      <Breadcrumbs actions={actions} crumbs={[{ content: meta.name }]} />
       <div className={styles.gameLanding}>
         <button className={styles.gameButtonLink} onClick={actions.new}>
           Start a local game


### PR DESCRIPTION
Instead of having crumbs in `BattleHistory`, `BattleControls` and `GameLanding`, lift the logic up to `GamePage`.