### PR TITLE
Stop doing throwaway objects in reductions

### DIFF
--- a/modules/logic/def2code/executors/expression/parser/parser.set.ts
+++ b/modules/logic/def2code/executors/expression/parser/parser.set.ts
@@ -91,7 +91,7 @@ export default function parseSet(
     // arr of the keys we want to keep
     const validKeys = `${targetKeys}.filter(${keyTester})`;
     // turn valid keys back into a set object
-    return `${validKeys}.reduce((m, k) => ({...m, [k]: emptyObj}), {})`;
+    return `${validKeys}.reduce((m, k) => { m[k] = emptyObj; return m; }, {})`;
   }
 
   if (isAlgolSetIntersect(expr)) {
@@ -103,13 +103,13 @@ export default function parseSet(
       .map(r => `.concat(Object.keys(${parser.set(r)}))`)
       .join("")}`;
     // reduce keys to an object with count per key
-    const countObj = `${keysArr}.reduce((mem, k) => ({...mem, [k]: (mem[k] || 0) + 1}), {})`;
+    const countObj = `${keysArr}.reduce((mem, k) => { mem[k] = (mem[k] || 0) + 1; return mem; }, {})`;
     // func that returns true if value of entry equals number of total sets
     const entryTester = `([key,n]) => n === ${rest.length + 1}`;
     // transform keys to object entries and keep only those with sufficient count
     const validEntries = `Object.entries(${countObj}).filter(${entryTester})`;
     // Turn those valid entries into an object again!
-    return `${validEntries}.reduce((mem, [key]) => ({...mem, [key]: emptyObj}), {})`;
+    return `${validEntries}.reduce((mem, [key]) => { mem[key] = emptyObj; return mem; }, {})`;
   }
 
   if (isAlgolSetGroupAt(expr)) {
@@ -128,7 +128,7 @@ export default function parseSet(
     // arr of the keys we want to keep
     const validKeys = `${targetKeys}.filter(k => k !== ${exceptPos})`;
     // turn valid keys back into a set object
-    return `${validKeys}.reduce((m, k) => ({...m, [k]: emptyObj}), {})`;
+    return `${validKeys}.reduce((m, k) => { m[k] = emptyObj; return m; }, {})`;
   }
 
   throw new Error(`Unknown set definition: ${JSON.stringify(expr)}`);

--- a/modules/logic/generated/aries.js
+++ b/modules/logic/generated/aries.js
@@ -367,10 +367,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN1.oppcorner)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -379,10 +385,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN1.oppcorner)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -465,10 +477,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN2.oppcorner)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -477,10 +495,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN2.oppcorner)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";

--- a/modules/logic/generated/chameleon.js
+++ b/modules/logic/generated/chameleon.js
@@ -93,10 +93,16 @@ const game = {
       let filtersourcelayer = Object.entries(
         Object.keys(UNITLAYERS.oppunits)
           .concat(Object.keys(TERRAIN1.mybase))
-          .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+          .reduce((mem, k) => {
+            mem[k] = (mem[k] || 0) + 1;
+            return mem;
+          }, {})
       )
         .filter(([key, n]) => n === 2)
-        .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {});
+        .reduce((mem, [key]) => {
+          mem[key] = emptyObj;
+          return mem;
+        }, {});
       let filtertargetlayer = ARTIFACTS.invaders;
       for (let POS in filtersourcelayer) {
         let filterObj = filtersourcelayer[POS];
@@ -133,10 +139,16 @@ const game = {
       let filtersourcelayer = Object.entries(
         Object.keys(UNITLAYERS.oppunits)
           .concat(Object.keys(TERRAIN2.mybase))
-          .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+          .reduce((mem, k) => {
+            mem[k] = (mem[k] || 0) + 1;
+            return mem;
+          }, {})
       )
         .filter(([key, n]) => n === 2)
-        .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {});
+        .reduce((mem, [key]) => {
+          mem[key] = emptyObj;
+          return mem;
+        }, {});
       let filtertargetlayer = ARTIFACTS.invaders;
       for (let POS in filtersourcelayer) {
         let filterObj = filtersourcelayer[POS];

--- a/modules/logic/generated/coffee.js
+++ b/modules/logic/generated/coffee.js
@@ -251,7 +251,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -363,7 +366,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -475,7 +481,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -587,7 +596,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -699,7 +711,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -811,7 +826,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -923,7 +941,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {
@@ -1035,7 +1056,10 @@ const game = {
       }
       for (let LOOPPOS in Object.keys(UNITLAYERS.neutralunits)
         .filter(k => k !== MARKS.selectdrop)
-        .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})) {
+        .reduce((m, k) => {
+          m[k] = emptyObj;
+          return m;
+        }, {})) {
         delete UNITDATA[(UNITLAYERS.units[LOOPPOS] || {}).id];
       }
       if (!UNITLAYERS.units[MARKS.selectdrop]) {

--- a/modules/logic/generated/daggers.js
+++ b/modules/logic/generated/daggers.js
@@ -321,10 +321,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mycrowns)
               .concat(Object.keys(TERRAIN1.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -333,10 +339,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mycrowns)
               .concat(Object.keys(TERRAIN1.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (Object.keys(UNITLAYERS.oppcrowns).length === 1) {
         LINKS.endGame = "win";
@@ -391,10 +403,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mycrowns)
               .concat(Object.keys(TERRAIN2.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -403,10 +421,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mycrowns)
               .concat(Object.keys(TERRAIN2.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (Object.keys(UNITLAYERS.oppcrowns).length === 1) {
         LINKS.endGame = "win";

--- a/modules/logic/generated/duplo.js
+++ b/modules/logic/generated/duplo.js
@@ -96,7 +96,10 @@ const game = {
         for (const pos of Object.keys(
           Object.keys(BOARD.board)
             .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectdeploy_basic_1";
         }
@@ -134,7 +137,10 @@ const game = {
         for (const pos of Object.keys(
           Object.keys(BOARD.board)
             .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectdeploy_basic_2";
         }
@@ -206,7 +212,10 @@ const game = {
       {
         let allowedsteps = Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {});
         let BLOCKS = UNITLAYERS.oppunits;
         for (let STARTPOS in ARTIFACTS.growstarts) {
           let DIR = (ARTIFACTS.growstarts[STARTPOS] || {}).dir;
@@ -379,7 +388,10 @@ const game = {
       {
         let allowedsteps = Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {});
         let BLOCKS = UNITLAYERS.oppunits;
         for (let STARTPOS in ARTIFACTS.growstarts) {
           let DIR = (ARTIFACTS.growstarts[STARTPOS] || {}).dir;
@@ -531,7 +543,10 @@ const game = {
         for (const pos of Object.keys(
           Object.keys(BOARD.board)
             .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectdeploy_basic_1";
         }
@@ -681,7 +696,10 @@ const game = {
         for (const pos of Object.keys(
           Object.keys(BOARD.board)
             .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectdeploy_basic_2";
         }

--- a/modules/logic/generated/gekitai.js
+++ b/modules/logic/generated/gekitai.js
@@ -66,7 +66,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectdroptarget_basic_1";
       }
@@ -94,7 +97,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectdroptarget_basic_2";
       }

--- a/modules/logic/generated/gogol.js
+++ b/modules/logic/generated/gogol.js
@@ -102,10 +102,16 @@ const game = {
       for (let STARTPOS in Object.entries(
         Object.keys(TERRAIN1.edges)
           .concat(Object.keys(UNITLAYERS.mysoldiers))
-          .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+          .reduce((mem, k) => {
+            mem[k] = (mem[k] || 0) + 1;
+            return mem;
+          }, {})
       )
         .filter(([key, n]) => n === 2)
-        .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})) {
+        .reduce((mem, [key]) => {
+          mem[key] = emptyObj;
+          return mem;
+        }, {})) {
         let startconnections = connections[STARTPOS];
         for (let DIR of TERRAIN1.homerow[STARTPOS] ? orthoDirs : [1, 5]) {
           let POS = startconnections[DIR];
@@ -138,7 +144,10 @@ const game = {
               k =>
                 !{ ...UNITLAYERS.units, ...ARTIFACTS.nokings }.hasOwnProperty(k)
             )
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectkingdeploy_basic_1";
         }
@@ -177,10 +186,16 @@ const game = {
       for (let STARTPOS in Object.entries(
         Object.keys(TERRAIN2.edges)
           .concat(Object.keys(UNITLAYERS.mysoldiers))
-          .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+          .reduce((mem, k) => {
+            mem[k] = (mem[k] || 0) + 1;
+            return mem;
+          }, {})
       )
         .filter(([key, n]) => n === 2)
-        .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})) {
+        .reduce((mem, [key]) => {
+          mem[key] = emptyObj;
+          return mem;
+        }, {})) {
         let startconnections = connections[STARTPOS];
         for (let DIR of TERRAIN2.homerow[STARTPOS] ? orthoDirs : [1, 5]) {
           let POS = startconnections[DIR];
@@ -213,7 +228,10 @@ const game = {
               k =>
                 !{ ...UNITLAYERS.units, ...ARTIFACTS.nokings }.hasOwnProperty(k)
             )
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectkingdeploy_basic_2";
         }
@@ -314,7 +332,10 @@ const game = {
                     ...ARTIFACTS.jumptargets
                   }.hasOwnProperty(k)
               )
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {})
       )) {
         LINKS.marks[pos] = "selectmovetarget_basic_1";
       }
@@ -472,7 +493,10 @@ const game = {
                     ...ARTIFACTS.jumptargets
                   }.hasOwnProperty(k)
               )
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {})
       )) {
         LINKS.marks[pos] = "selectmovetarget_basic_2";
       }
@@ -624,10 +648,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -636,10 +666,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (TURN > 1 && Object.keys(UNITLAYERS.oppkings).length === 0) {
         LINKS.endGame = "win";
@@ -706,10 +742,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -718,10 +760,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (TURN > 1 && Object.keys(UNITLAYERS.oppkings).length === 0) {
         LINKS.endGame = "win";
@@ -819,10 +867,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -831,10 +885,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (TURN > 1 && Object.keys(UNITLAYERS.oppkings).length === 0) {
         LINKS.endGame = "win";
@@ -901,10 +961,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -913,10 +979,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (TURN > 1 && Object.keys(UNITLAYERS.oppkings).length === 0) {
         LINKS.endGame = "win";
@@ -1010,13 +1082,16 @@ const game = {
                         ...ARTIFACTS.jumptargets
                       })
                     )
-                    .reduce(
-                      (mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }),
-                      {}
-                    )
+                    .reduce((mem, k) => {
+                      mem[k] = (mem[k] || 0) + 1;
+                      return mem;
+                    }, {})
                 )
                   .filter(([key, n]) => n === 2)
-                  .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+                  .reduce((mem, [key]) => {
+                    mem[key] = emptyObj;
+                    return mem;
+                  }, {})
               ).length !== 0
                 ? { text: "without making a forbidden configuration" }
                 : undefined
@@ -1165,13 +1240,16 @@ const game = {
                         ...ARTIFACTS.jumptargets
                       })
                     )
-                    .reduce(
-                      (mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }),
-                      {}
-                    )
+                    .reduce((mem, k) => {
+                      mem[k] = (mem[k] || 0) + 1;
+                      return mem;
+                    }, {})
                 )
                   .filter(([key, n]) => n === 2)
-                  .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+                  .reduce((mem, [key]) => {
+                    mem[key] = emptyObj;
+                    return mem;
+                  }, {})
               ).length !== 0
                 ? { text: "without making a forbidden configuration" }
                 : undefined

--- a/modules/logic/generated/gowiththefloe.js
+++ b/modules/logic/generated/gowiththefloe.js
@@ -187,7 +187,10 @@ const game = {
               !TERRAIN1.water.hasOwnProperty(k) &&
               !UNITLAYERS.holes.hasOwnProperty(k)
           )
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {});
         for (let DIR of roseDirs) {
           let walkedsquares = [];
           let STOPREASON = "";
@@ -330,7 +333,10 @@ const game = {
               !TERRAIN2.water.hasOwnProperty(k) &&
               !UNITLAYERS.holes.hasOwnProperty(k)
           )
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {});
         for (let DIR of roseDirs) {
           let walkedsquares = [];
           let STOPREASON = "";
@@ -516,7 +522,10 @@ const game = {
             let POS = STARTPOS;
             let walkpositionstocount = Object.keys(TERRAIN1.nowater)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {});
             let CURRENTCOUNT = 0;
             let LENGTH = 0;
             while (LENGTH < MAX && (POS = connections[POS][DIR])) {
@@ -543,7 +552,10 @@ const game = {
         LINKS.endMarks = Object.keys(
           Object.keys(UNITLAYERS.seals)
             .filter(k => !ARTIFACTS.canmove.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -609,7 +621,10 @@ const game = {
             let POS = STARTPOS;
             let walkpositionstocount = Object.keys(TERRAIN1.nowater)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {});
             let CURRENTCOUNT = 0;
             let LENGTH = 0;
             while (LENGTH < MAX && (POS = connections[POS][DIR])) {
@@ -636,7 +651,10 @@ const game = {
         LINKS.endMarks = Object.keys(
           Object.keys(UNITLAYERS.seals)
             .filter(k => !ARTIFACTS.canmove.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -706,7 +724,10 @@ const game = {
             let POS = STARTPOS;
             let walkpositionstocount = Object.keys(TERRAIN2.nowater)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {});
             let CURRENTCOUNT = 0;
             let LENGTH = 0;
             while (LENGTH < MAX && (POS = connections[POS][DIR])) {
@@ -733,7 +754,10 @@ const game = {
         LINKS.endMarks = Object.keys(
           Object.keys(UNITLAYERS.seals)
             .filter(k => !ARTIFACTS.canmove.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";
@@ -800,7 +824,10 @@ const game = {
             let POS = STARTPOS;
             let walkpositionstocount = Object.keys(TERRAIN2.nowater)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {});
             let CURRENTCOUNT = 0;
             let LENGTH = 0;
             while (LENGTH < MAX && (POS = connections[POS][DIR])) {
@@ -827,7 +854,10 @@ const game = {
         LINKS.endMarks = Object.keys(
           Object.keys(UNITLAYERS.seals)
             .filter(k => !ARTIFACTS.canmove.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";
@@ -879,7 +909,10 @@ const game = {
             let POS = STARTPOS;
             let walkpositionstocount = Object.keys(TERRAIN2.nowater)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
-              .reduce((m, k) => ({ ...m, [k]: emptyObj }), {});
+              .reduce((m, k) => {
+                m[k] = emptyObj;
+                return m;
+              }, {});
             let CURRENTCOUNT = 0;
             let LENGTH = 0;
             while (LENGTH < MAX && (POS = connections[POS][DIR])) {
@@ -906,7 +939,10 @@ const game = {
         LINKS.endMarks = Object.keys(
           Object.keys(UNITLAYERS.seals)
             .filter(k => !ARTIFACTS.canmove.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";

--- a/modules/logic/generated/kickrun.js
+++ b/modules/logic/generated/kickrun.js
@@ -277,10 +277,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myrunners)
               .concat(Object.keys(TERRAIN1.oppcorners))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -289,10 +295,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myrunners)
               .concat(Object.keys(TERRAIN1.oppcorners))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -341,10 +353,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myrunners)
               .concat(Object.keys(TERRAIN2.oppcorners))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -353,10 +371,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myrunners)
               .concat(Object.keys(TERRAIN2.oppcorners))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";

--- a/modules/logic/generated/krieg.js
+++ b/modules/logic/generated/krieg.js
@@ -280,10 +280,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN1.oppcorners)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -292,20 +298,32 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN1.oppcorners)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (
         Object.keys(
           Object.entries(
             Object.keys(TERRAIN1.oppbases)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length === 2
       ) {
         LINKS.endGame = "win";
@@ -314,10 +332,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN1.oppbases)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -386,10 +410,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN2.oppcorners)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -398,20 +428,32 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN2.oppcorners)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else if (
         Object.keys(
           Object.entries(
             Object.keys(TERRAIN2.oppbases)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length === 2
       ) {
         LINKS.endGame = "win";
@@ -420,10 +462,16 @@ const game = {
           Object.entries(
             Object.keys(TERRAIN2.oppbases)
               .concat(Object.keys(UNITLAYERS.myunits))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";

--- a/modules/logic/generated/momentum.js
+++ b/modules/logic/generated/momentum.js
@@ -75,7 +75,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectdroptarget_basic_1";
       }
@@ -105,7 +108,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectdroptarget_basic_2";
       }

--- a/modules/logic/generated/murusgallicus.js
+++ b/modules/logic/generated/murusgallicus.js
@@ -945,10 +945,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -957,10 +963,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -1031,10 +1043,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1043,10 +1061,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -1145,10 +1169,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1157,10 +1187,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";
@@ -1231,10 +1267,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1243,10 +1285,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";
@@ -1345,10 +1393,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1357,10 +1411,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_2";
@@ -1431,10 +1491,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1443,10 +1509,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_2";
@@ -1505,10 +1577,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1517,10 +1595,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_2";
@@ -1610,10 +1694,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1622,10 +1712,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_2";
@@ -1724,10 +1820,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1736,10 +1838,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_1";
@@ -1810,10 +1918,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1822,10 +1936,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_1";
@@ -1884,10 +2004,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -1896,10 +2022,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_1";
@@ -1989,10 +2121,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -2001,10 +2139,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.opphomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_advanced_1";

--- a/modules/logic/generated/serauqs.js
+++ b/modules/logic/generated/serauqs.js
@@ -327,10 +327,16 @@ const game = {
               .concat(
                 Object.keys({ ...UNITLAYERS.myunits, ...UNITLAYERS.oppwild })
               )
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length > 3
       ) {
         LINKS.endGame = "win";
@@ -343,10 +349,16 @@ const game = {
               .concat(
                 Object.keys({ ...UNITLAYERS.myunits, ...UNITLAYERS.oppwild })
               )
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length > 3
       ) {
         LINKS.endGame = "win";
@@ -471,10 +483,16 @@ const game = {
               .concat(
                 Object.keys({ ...UNITLAYERS.myunits, ...UNITLAYERS.oppwild })
               )
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length > 3
       ) {
         LINKS.endGame = "win";
@@ -487,10 +505,16 @@ const game = {
               .concat(
                 Object.keys({ ...UNITLAYERS.myunits, ...UNITLAYERS.oppwild })
               )
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length > 3
       ) {
         LINKS.endGame = "win";

--- a/modules/logic/generated/trafficlights.js
+++ b/modules/logic/generated/trafficlights.js
@@ -95,7 +95,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectdeploytarget_basic_1";
       }
@@ -130,7 +133,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(BOARD.board)
           .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectdeploytarget_basic_2";
       }

--- a/modules/logic/generated/transet.js
+++ b/modules/logic/generated/transet.js
@@ -155,7 +155,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(UNITLAYERS.myunits)
           .filter(k => !{ [MARKS.selectunit]: 1 }.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectswapunit_basic_1";
       }
@@ -182,7 +185,10 @@ const game = {
         for (const pos of Object.keys(
           Object.keys(TERRAIN1.oppbase)
             .filter(k => !UNITLAYERS.oppunits.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectdeportdestination_basic_1";
         }
@@ -313,7 +319,10 @@ const game = {
       for (const pos of Object.keys(
         Object.keys(UNITLAYERS.myunits)
           .filter(k => !{ [MARKS.selectunit]: 1 }.hasOwnProperty(k))
-          .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+          .reduce((m, k) => {
+            m[k] = emptyObj;
+            return m;
+          }, {})
       )) {
         LINKS.marks[pos] = "selectswapunit_basic_2";
       }
@@ -340,7 +349,10 @@ const game = {
         for (const pos of Object.keys(
           Object.keys(TERRAIN2.oppbase)
             .filter(k => !UNITLAYERS.oppunits.hasOwnProperty(k))
-            .reduce((m, k) => ({ ...m, [k]: emptyObj }), {})
+            .reduce((m, k) => {
+              m[k] = emptyObj;
+              return m;
+            }, {})
         )) {
           LINKS.marks[pos] = "selectdeportdestination_basic_2";
         }
@@ -491,10 +503,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -503,10 +521,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -567,10 +591,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -579,10 +609,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN1.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -644,10 +680,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -656,10 +698,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";
@@ -720,10 +768,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -732,10 +786,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.myunits)
               .concat(Object.keys(TERRAIN2.oppbase))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";

--- a/modules/logic/generated/uglyduck.js
+++ b/modules/logic/generated/uglyduck.js
@@ -282,10 +282,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN1.myhomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -294,10 +300,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN1.myhomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_2";
@@ -358,10 +370,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN2.myhomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         ).length !== 0
       ) {
         LINKS.endGame = "win";
@@ -370,10 +388,16 @@ const game = {
           Object.entries(
             Object.keys(UNITLAYERS.mykings)
               .concat(Object.keys(TERRAIN2.myhomerow))
-              .reduce((mem, k) => ({ ...mem, [k]: (mem[k] || 0) + 1 }), {})
+              .reduce((mem, k) => {
+                mem[k] = (mem[k] || 0) + 1;
+                return mem;
+              }, {})
           )
             .filter(([key, n]) => n === 2)
-            .reduce((mem, [key]) => ({ ...mem, [key]: emptyObj }), {})
+            .reduce((mem, [key]) => {
+              mem[key] = emptyObj;
+              return mem;
+            }, {})
         );
       } else {
         LINKS.endTurn = "startTurn_basic_1";

--- a/modules/ui/src/components/GamePage/GamePage.tsx
+++ b/modules/ui/src/components/GamePage/GamePage.tsx
@@ -133,6 +133,7 @@ export const GamePage = (props: GamePageProps) => {
           potentialMarks={ui.board.potentialMarks}
           anim={ui.board.anim}
           active={mode === "playing" && !battle!.gameEndedBy}
+          name={battle ? battle.variant.board : "basic"}
         />
       }
       strip={

--- a/modules/ui/src/components/SessionList/SessionList.Item.tsx
+++ b/modules/ui/src/components/SessionList/SessionList.Item.tsx
@@ -39,6 +39,7 @@ export const SessionListItem: FunctionComponent<SessionListItemProps> = props =>
           potentialMarks={EMPTYARR}
           marks={board.marks}
           units={board.units}
+          name={variant.board}
         />
       </div>
       <SessionItemInfo session={session} variant={variant} />


### PR DESCRIPTION
Change all reductions in generated code to mutate `memo` instead of spreading it into a new object.

(also a commit for board variants that was forgotten in the King's Valley PR)