### PR TITLE
Link static data into compilation

### DIFF
--- a/modules/logic/def2code/index.ts
+++ b/modules/logic/def2code/index.ts
@@ -84,6 +84,10 @@ import {offsetPos, boardConnections, makeRelativeDirs, setup2army, coords2pos, b
     hasGrids ? ", makeGrids" : ""
   }} from '../../common'
 
+import boards from '../../games/definitions/${gameDef.meta.id}/boards'
+import setups from '../../games/definitions/${gameDef.meta.id}/setups'
+import variants from '../../games/definitions/${gameDef.meta.id}/variants'
+
 ${executeSection(gameDef, 1, "head", "allRulesets", "head")}
 
 ${ruleNames
@@ -108,9 +112,9 @@ const game = {
   instruction: {
     ${instructions.join(", ")}
   },
-  variants: ${JSON.stringify(gameDef.variants, null, 2)},
-  boards: ${JSON.stringify(gameDef.boards, null, 2)},
-  setups: ${JSON.stringify(gameDef.setups, null, 2)}
+  variants,
+  boards,
+  setups
 };
 
 export default game; 

--- a/modules/logic/generated/allqueenschess.js
+++ b/modules/logic/generated/allqueenschess.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/allqueenschess/boards";
+import setups from "../../games/definitions/allqueenschess/setups";
+import variants from "../../games/definitions/allqueenschess/variants";
 const emptyObj = {};
 const iconMapping = { queens: "queen" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -411,39 +414,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          queens: {
-            "1": ["a3", "b5", "c1", "c4", "d4", "d5"],
-            "2": ["b1", "c3", "c5", "d3", "e3"]
-          }
-        },
-        marks: ["b1"],
-        potentialMarks: ["a1", "a2", "c2", "b2", "b3", "b4"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      queens: {
-        "1": ["a1", "c1", "e1", "b5", "d5", "a3"],
-        "2": ["a5", "c5", "e5", "b1", "d1", "e3"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/amazons.js
+++ b/modules/logic/generated/amazons.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/amazons/boards";
+import setups from "../../games/definitions/amazons/setups";
+import variants from "../../games/definitions/amazons/variants";
 const emptyObj = {};
 const iconMapping = { amazons: "queen", fires: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -588,74 +591,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "f",
-      arr: {
-        marks: ["j4"],
-        potentialMarks: [
-          "g1",
-          "j1",
-          "h2",
-          "j2",
-          "i3",
-          "j3",
-          "i4",
-          "i5",
-          "j5",
-          "h6",
-          "j6",
-          "g7",
-          "j7",
-          "f8",
-          "j8",
-          "j9",
-          "j10"
-        ],
-        setup: {
-          fires: {
-            "0": [
-              "e2",
-              "d3",
-              "b4",
-              "h4",
-              "c5",
-              "d5",
-              "b6",
-              "c6",
-              "g6",
-              "b7",
-              "b8",
-              "b9",
-              "h9"
-            ]
-          },
-          amazons: {
-            "1": ["f3", "b5", "d6", "e9"],
-            "2": ["d4", "j4", "f6", "a9"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 10,
-      width: 10,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      amazons: {
-        "1": ["d10", "g10", "a7", "j7"],
-        "2": ["a4", "d1", "g1", "j4"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/ambivalente.js
+++ b/modules/logic/generated/ambivalente.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/ambivalente/boards";
+import setups from "../../games/definitions/ambivalente/setups";
+import variants from "../../games/definitions/ambivalente/variants";
 const emptyObj = {};
 const iconMapping = { pawns: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -582,59 +585,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          pawns: {
-            "0": ["a6", "e6", "b2", "b3", "d3", "e1", "f2"],
-            "1": ["b5", "c3", "f1", "f5"],
-            "2": ["a5", "b1", "b6", "d6", "f6"]
-          }
-        },
-        marks: [],
-        potentialMarks: [
-          "a1",
-          "a2",
-          "a3",
-          "a4",
-          "b4",
-          "c1",
-          "c2",
-          "c4",
-          "c5",
-          "c6",
-          "d1",
-          "d2",
-          "d4",
-          "d5",
-          "e2",
-          "e3",
-          "e4",
-          "e5",
-          "f3",
-          "f4"
-        ]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 6,
-      width: 6,
-      terrain: {
-        corners: ["a1", "f1", "a6", "f6"]
-      },
-      offsets: [["rose", 2, 0]]
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/aries.js
+++ b/modules/logic/generated/aries.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/aries/boards";
+import setups from "../../games/definitions/aries/setups";
+import variants from "../../games/definitions/aries/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "rook" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -708,52 +711,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "e",
-      arr: {
-        marks: ["c7"],
-        potentialMarks: ["c4", "c5", "c6", "a7", "b7", "d7", "e7", "c8"],
-        setup: {
-          soldiers: {
-            "1": ["a1", "b1", "a2", "a3", "c3", "a4", "b4", "c7", "d8"],
-            "2": ["g1", "b5", "f6", "h6", "e7", "f7", "h7", "f8", "h8"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        corner: {
-          "1": ["a1"],
-          "2": ["h8"]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "d4"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["e5", "h8"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/ataxx.js
+++ b/modules/logic/generated/ataxx.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/ataxx/boards";
+import setups from "../../games/definitions/ataxx/setups";
+import variants from "../../games/definitions/ataxx/variants";
 const emptyObj = {};
 const iconMapping = { microbes: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -835,80 +838,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          microbes: {
-            "1": [
-              "a1",
-              "a2",
-              "b1",
-              "b2",
-              "b6",
-              "c1",
-              "c2",
-              "c3",
-              "c6",
-              "d1",
-              "d2",
-              "d3",
-              "d4",
-              "e1",
-              "f3",
-              "f4",
-              "g1",
-              "g2"
-            ],
-            "2": [
-              "a3",
-              "a4",
-              "b3",
-              "b4",
-              "b5",
-              "c4",
-              "c5",
-              "d5",
-              "d6",
-              "e2",
-              "e3",
-              "e4",
-              "e5",
-              "e6",
-              "f1",
-              "f2",
-              "f5",
-              "g3",
-              "g4",
-              "g5"
-            ]
-          }
-        },
-        marks: ["b5"],
-        potentialMarks: ["a5", "a6", "a7", "b7", "c7", "d7"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 7,
-      width: 7,
-      terrain: {},
-      offset: "ring2"
-    }
-  },
-  setups: {
-    basic: {
-      microbes: {
-        "1": ["a7", "g1"],
-        "2": ["a1", "g7"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/atrium.js
+++ b/modules/logic/generated/atrium.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/atrium/boards";
+import setups from "../../games/definitions/atrium/setups";
+import variants from "../../games/definitions/atrium/variants";
 const emptyObj = {};
 const iconMapping = { kings: "king", queens: "queen" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -800,47 +803,8 @@ const game = {
           });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "x",
-      arr: {
-        marks: ["b2"],
-        potentialMarks: ["a2", "c2"],
-        setup: {
-          kings: {
-            "1": ["b2", "d2", "c4"],
-            "2": ["b1", "d3", "b4"]
-          },
-          queens: {
-            "1": ["d1", "b3", "d5"],
-            "2": ["c3", "a4", "e4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      kings: {
-        "1": ["a2", "c5", "e2"],
-        "2": ["b1", "b5", "e3"]
-      },
-      queens: {
-        "1": ["a3", "d5", "d1"],
-        "2": ["a4", "c1", "e4"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/bombardment.js
+++ b/modules/logic/generated/bombardment.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/bombardment/boards";
+import setups from "../../games/definitions/bombardment/setups";
+import variants from "../../games/definitions/bombardment/variants";
 const emptyObj = {};
 const iconMapping = { rockets: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -585,60 +588,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          rockets: {
-            "1": ["a2", "g2", "g5", "h1"],
-            "2": ["e4", "e8", "f6", "f8", "g8"]
-          }
-        },
-        marks: ["e4"],
-        potentialMarks: ["d3", "e3", "f3"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a8", "h8"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      rockets: {
-        "1": [
-          {
-            rect: ["a1", "h2"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a7", "h8"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/breakthrough.js
+++ b/modules/logic/generated/breakthrough.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/breakthrough/boards";
+import setups from "../../games/definitions/breakthrough/setups";
+import variants from "../../games/definitions/breakthrough/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -912,175 +915,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          soldiers: {
-            "1": [
-              "b1",
-              "b4",
-              "c3",
-              "c4",
-              "d3",
-              "d4",
-              "e3",
-              "e4",
-              "f1",
-              "f3",
-              "f4",
-              "g1",
-              "g2",
-              "h4"
-            ],
-            "2": [
-              "b5",
-              "b6",
-              "b7",
-              "c5",
-              "c7",
-              "d5",
-              "d6",
-              "e5",
-              "e6",
-              "f5",
-              "f6",
-              "f8",
-              "g4",
-              "g7",
-              "h5"
-            ]
-          }
-        },
-        marks: ["f4"],
-        potentialMarks: ["e5", "g5"]
-      }
-    },
-    {
-      ruleset: "basic",
-      board: "mini",
-      setup: "mini",
-      desc: "mini",
-      code: "M",
-      arr: {
-        setup: {},
-        marks: [],
-        potentialMarks: []
-      }
-    },
-    {
-      ruleset: "siege",
-      board: "siege",
-      setup: "siege",
-      desc: "siege",
-      code: "S",
-      arr: {
-        setup: {},
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a8", "h8"]
-            }
-          ]
-        }
-      }
-    },
-    mini: {
-      height: 5,
-      width: 5,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "e1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a5", "e5"]
-            }
-          ]
-        }
-      }
-    },
-    siege: {
-      height: 8,
-      width: 8,
-      terrain: {
-        base: {
-          "1": ["h1"],
-          "2": ["a8"]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "h2"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a7", "h8"]
-          }
-        ]
-      }
-    },
-    mini: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "e2"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a4", "e5"]
-          }
-        ]
-      }
-    },
-    siege: {
-      soldiers: {
-        "1": [
-          {
-            holerect: ["e1", "h4", "e3", "e4", "f4", "h1"]
-          },
-          "d1",
-          "h5"
-        ],
-        "2": [
-          {
-            holerect: ["a5", "d8", "c5", "d5", "d6", "a8"]
-          },
-          "a4",
-          "e8"
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/campaign.js
+++ b/modules/logic/generated/campaign.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/campaign/boards";
+import setups from "../../games/definitions/campaign/setups";
+import variants from "../../games/definitions/campaign/variants";
 const emptyObj = {};
 const iconMapping = { knights: "knight", marks: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -698,41 +701,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          knights: {
-            "1": ["d5"],
-            "2": ["e4"]
-          },
-          marks: {
-            "1": ["d4", "e6", "f4", "f5"],
-            "2": ["c5", "d3", "d6", "e4"]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 10,
-      width: 10,
-      terrain: {
-        center: ["e5", "e6", "f5", "f6"]
-      },
-      offset: "knight"
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/chameleon.js
+++ b/modules/logic/generated/chameleon.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/chameleon/boards";
+import setups from "../../games/definitions/chameleon/setups";
+import variants from "../../games/definitions/chameleon/variants";
 const emptyObj = {};
 const iconMapping = { knights: "knight", bishops: "bishop" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -814,76 +817,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "w",
-      arr: {
-        marks: ["d4"],
-        potentialMarks: [
-          "a1",
-          "b2",
-          "c3",
-          "d3",
-          "e3",
-          "c4",
-          "e4",
-          "c5",
-          "d5",
-          "e5"
-        ],
-        setup: {
-          knights: {
-            "1": ["a1", "c4"],
-            "2": ["b4", "a5"]
-          },
-          bishops: {
-            "1": ["c2", "d2"],
-            "2": ["d4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "e1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a5", "e5"]
-            }
-          ]
-        }
-      },
-      offset: "knight"
-    }
-  },
-  setups: {
-    basic: {
-      knights: {
-        "1": [
-          {
-            rect: ["a1", "e1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a5", "e5"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/coffee.js
+++ b/modules/logic/generated/coffee.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/coffee/boards";
+import setups from "../../games/definitions/coffee/setups";
+import variants from "../../games/definitions/coffee/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1281,35 +1284,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "z",
-      arr: {
-        marks: [],
-        potentialMarks: ["b2", "b3", "b4", "b5"],
-        setup: {
-          soldiers: {
-            "0": ["b2", "b3", "b4", "b5"],
-            "1": ["d1", "c3", "e5"],
-            "2": ["b1", "e3", "d4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/connectfour.js
+++ b/modules/logic/generated/connectfour.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/connectfour/boards";
+import setups from "../../games/definitions/connectfour/setups";
+import variants from "../../games/definitions/connectfour/variants";
 const emptyObj = {};
 const iconMapping = { markers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -385,40 +388,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          markers: {
-            "1": ["c1", "d1", "d2", "d3", "e3"],
-            "2": ["b1", "c2", "e1", "e2"]
-          }
-        },
-        marks: [],
-        potentialMarks: ["a1", "b2", "c3", "d4", "e4", "f1", "g1"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 6,
-      width: 7,
-      terrain: {
-        edge: [
-          {
-            rect: ["a6", "g6"]
-          }
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/crossings.js
+++ b/modules/logic/generated/crossings.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/crossings/boards";
+import setups from "../../games/definitions/crossings/setups";
+import variants from "../../games/definitions/crossings/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn", towers: "rook" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1231,92 +1234,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          soldiers: {
-            "1": [
-              "a1",
-              "a2",
-              "b2",
-              "c1",
-              "d3",
-              "d4",
-              "e1",
-              "e2",
-              "e3",
-              "e4",
-              "f1",
-              "f2",
-              "g2",
-              "h1",
-              "h2"
-            ],
-            "2": [
-              "a7",
-              "a8",
-              "b7",
-              "b8",
-              "c7",
-              "d8",
-              "e6",
-              "e7",
-              "e8",
-              "f5",
-              "f6",
-              "g7",
-              "g8",
-              "h7",
-              "h8"
-            ]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a8", "h8"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "h2"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a7", "h8"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/daggers.js
+++ b/modules/logic/generated/daggers.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/daggers/boards";
+import setups from "../../games/definitions/daggers/setups";
+import variants from "../../games/definitions/daggers/variants";
 const emptyObj = {};
 const iconMapping = { daggers: "bishop", crowns: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -660,70 +663,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "a",
-      arr: {
-        marks: ["c6"],
-        potentialMarks: ["a4", "c4", "e4", "b5", "c5", "d5", "b7", "c7"],
-        setup: {
-          crowns: {
-            "1": ["b6", "d8"],
-            "2": ["f1", "c2"]
-          },
-          daggers: {
-            "1": ["c6", "e6", "d7", "f7"],
-            "2": ["d2", "f2", "g2", "b3", "c3", "f3", "b4", "e4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a8", "h8"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      crowns: {
-        "1": ["d8", "e8"],
-        "2": ["c1", "f1"]
-      },
-      daggers: {
-        "1": [
-          {
-            rect: ["c7", "f7"]
-          }
-        ],
-        "2": [
-          "c3",
-          "f3",
-          {
-            rect: ["b2", "g2"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/descent.js
+++ b/modules/logic/generated/descent.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/descent/boards";
+import setups from "../../games/definitions/descent/setups";
+import variants from "../../games/definitions/descent/variants";
 const emptyObj = {};
 const iconMapping = {
   lvl3: "queen",
@@ -1116,58 +1119,8 @@ const game = {
           });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "m",
-      arr: {
-        marks: ["b3"],
-        potentialMarks: ["a2", "c3", "a4"],
-        setup: {
-          lvl3: {
-            "0": ["a1", "c1", "d1", "a2", "d2", "a4", "d4"],
-            "2": ["b1"]
-          },
-          lvl1: {
-            "0": ["c3", "d3"],
-            "1": ["c2"],
-            "2": ["b2"]
-          },
-          lvl0: {
-            "0": ["a3"]
-          },
-          lvl2: {
-            "1": ["b3", "c4"],
-            "2": ["b4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 4,
-      width: 4,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      lvl3: {
-        "0": [
-          {
-            rect: ["a2", "d3"]
-          },
-          "b4",
-          "c1"
-        ],
-        "1": ["a1", "c4", "d1"],
-        "2": ["a4", "b1", "d4"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/desdemona.js
+++ b/modules/logic/generated/desdemona.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/desdemona/boards";
+import setups from "../../games/definitions/desdemona/setups";
+import variants from "../../games/definitions/desdemona/variants";
 const emptyObj = {};
 const iconMapping = { amazons: "queen", stones: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -2849,112 +2852,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "pie",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "n",
-      arr: {
-        setup: {
-          amazons: {
-            "1": ["b7", "c4"],
-            "2": ["a5", "d4"]
-          },
-          stones: {
-            "1": ["a3", "b4", "c6", "d5", "d6", "e4"],
-            "2": ["b5", "b6", "c5"]
-          }
-        },
-        marks: ["d4"],
-        potentialMarks: [
-          "a1",
-          "b2",
-          "c3",
-          "d1",
-          "d2",
-          "d3",
-          "e3",
-          "e5",
-          "f2",
-          "f6",
-          "g1",
-          "g7"
-        ]
-      }
-    },
-    {
-      ruleset: "pie",
-      board: "xl",
-      setup: "xl",
-      desc: "XL",
-      code: "p"
-    },
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic_OLD",
-      desc: "regular (OLD)",
-      code: "r",
-      hidden: true
-    },
-    {
-      ruleset: "basic",
-      board: "xl",
-      setup: "xl_OLD",
-      desc: "XL (OLD)",
-      code: "x",
-      hidden: true
-    }
-  ],
-  boards: {
-    basic: {
-      height: 7,
-      width: 7,
-      terrain: {}
-    },
-    xl: {
-      height: 8,
-      width: 8,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      amazons: {
-        "1": ["b2", "f2"],
-        "2": ["b6", "f6"]
-      }
-    },
-    xl: {
-      amazons: {
-        "1": ["b2", "g2", "a4"],
-        "2": ["b7", "g7", "h5"]
-      }
-    },
-    basic_OLD: {
-      amazons: {
-        "1": ["a1", "g7"],
-        "2": ["a7", "g1"]
-      }
-    },
-    xl_OLD: {
-      amazons: {
-        "1": ["a1", "h8"],
-        "2": ["a8", "h1"]
-      }
-    },
-    blocktest: {
-      amazons: {
-        "1": ["b2", "f2", "g1"],
-        "2": ["a7"]
-      },
-      stones: {
-        "1": ["a6", "c2"],
-        "2": ["c4", "e6"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/duckpond.js
+++ b/modules/logic/generated/duckpond.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/duckpond/boards";
+import setups from "../../games/definitions/duckpond/setups";
+import variants from "../../games/definitions/duckpond/variants";
 const emptyObj = {};
 const iconMapping = { ducks: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -419,39 +422,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          ducks: {
-            "1": ["b2", "c2", "d3", "d5"],
-            "2": ["b3", "b5", "c4", "e2"]
-          }
-        },
-        marks: ["b3"],
-        potentialMarks: ["a2", "a3", "a4", "b1", "b4", "c3", "d1"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      ducks: {
-        "1": ["a2", "b1", "d5", "e4"],
-        "2": ["a4", "b5", "d1", "e2"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/duplo.js
+++ b/modules/logic/generated/duplo.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/duplo/boards";
+import setups from "../../games/definitions/duplo/setups";
+import variants from "../../games/definitions/duplo/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -945,35 +948,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "u",
-      arr: {
-        marks: ["c4"],
-        potentialMarks: ["b3", "d3", "b5", "c6"],
-        setup: {
-          soldiers: {
-            "0": ["e4", "d5", "e5"],
-            "1": ["a1", "b2", "c3", "a4", "b4", "c4", "d4"],
-            "2": ["g4", "f5", "d6", "e6", "d7", "e7", "d8"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/erdoslatino.js
+++ b/modules/logic/generated/erdoslatino.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/erdoslatino/boards";
+import setups from "../../games/definitions/erdoslatino/setups";
+import variants from "../../games/definitions/erdoslatino/variants";
 const emptyObj = {};
 const iconMapping = {
   lvl1: "pawn",
@@ -2171,66 +2174,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          lvl1: {
-            "1": ["c3"],
-            "2": ["b5"]
-          },
-          lvl2: {
-            "0": ["d4"]
-          },
-          lvl3: {
-            "0": ["d5"],
-            "2": ["b1"]
-          },
-          lvl4: {
-            "1": ["c4"],
-            "2": ["b3"]
-          },
-          lvl5: {
-            "1": ["c5"],
-            "2": ["b2"]
-          }
-        },
-        marks: [],
-        potentialMarks: [
-          "a1",
-          "a2",
-          "a3",
-          "a4",
-          "a5",
-          "b4",
-          "c1",
-          "c2",
-          "d1",
-          "d2",
-          "d3",
-          "e1",
-          "e2",
-          "e3",
-          "e4",
-          "e5"
-        ]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/euclid.js
+++ b/modules/logic/generated/euclid.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/euclid/boards";
+import setups from "../../games/definitions/euclid/setups";
+import variants from "../../games/definitions/euclid/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "rook", kings: "queen", projectiles: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -612,80 +615,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          kings: {
-            "1": ["h5"],
-            "2": ["d8"]
-          },
-          soldiers: {
-            "1": [
-              "a2",
-              "a3",
-              "b2",
-              "b3",
-              "b4",
-              "c3",
-              "c4",
-              "e2",
-              "e4",
-              "f1",
-              "h2"
-            ],
-            "2": [
-              "a4",
-              "b8",
-              "c8",
-              "e6",
-              "f5",
-              "f6",
-              "f7",
-              "g3",
-              "g6",
-              "g7",
-              "h6",
-              "h7"
-            ]
-          }
-        },
-        marks: ["e2"],
-        potentialMarks: ["c2", "d2", "e1", "e3", "f2", "g2"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      kings: {
-        "1": ["a1"],
-        "2": ["h8"]
-      },
-      soldiers: {
-        "1": [
-          {
-            holerect: ["a1", "d4", "a1"]
-          }
-        ],
-        "2": [
-          {
-            holerect: ["e5", "h8", "h8"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/gekitai.js
+++ b/modules/logic/generated/gekitai.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/gekitai/boards";
+import setups from "../../games/definitions/gekitai/setups";
+import variants from "../../games/definitions/gekitai/variants";
 const emptyObj = {};
 const iconMapping = { markers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -501,64 +504,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "u",
-      arr: {
-        marks: [],
-        potentialMarks: [
-          "b1",
-          "c1",
-          "d1",
-          "e1",
-          "f1",
-          "b2",
-          "c2",
-          "e2",
-          "f2",
-          "a3",
-          "b3",
-          "d3",
-          "e3",
-          "f3",
-          "a4",
-          "b4",
-          "c4",
-          "d4",
-          "f4",
-          "a5",
-          "b5",
-          "d5",
-          "e5",
-          "a6",
-          "b6",
-          "c6",
-          "d6",
-          "e6",
-          "f6"
-        ],
-        setup: {
-          markers: {
-            "1": ["a1", "d2", "c3"],
-            "2": ["a2", "e4", "c5", "f5"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 6,
-      width: 6,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/gogol.js
+++ b/modules/logic/generated/gogol.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/gogol/boards";
+import setups from "../../games/definitions/gogol/setups";
+import variants from "../../games/definitions/gogol/variants";
 const emptyObj = {};
 const iconMapping = { kings: "king", soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1334,123 +1337,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "d",
-      arr: {
-        marks: ["b1"],
-        potentialMarks: [
-          "c1",
-          "e1",
-          "f1",
-          "h1",
-          "a2",
-          "b2",
-          "c2",
-          "d2",
-          "e2",
-          "f2",
-          "g2",
-          "h2",
-          "a3",
-          "c3",
-          "e3",
-          "f3",
-          "g3",
-          "b4",
-          "c4",
-          "d4",
-          "e4",
-          "f4",
-          "g4",
-          "d5",
-          "e5",
-          "f5",
-          "g5",
-          "a6",
-          "b6",
-          "e6",
-          "g6",
-          "h6",
-          "a7",
-          "c7",
-          "d7",
-          "e7",
-          "f7",
-          "g7",
-          "h7",
-          "a8",
-          "c8",
-          "e8",
-          "g8",
-          "h8"
-        ],
-        setup: {
-          soldiers: {
-            "1": ["a1", "b1", "d1", "g1", "b3", "d3", "a4", "a5"],
-            "2": ["c5", "c6", "d6", "f6", "b7", "b8", "d8", "f8"]
-          },
-          kings: {
-            "1": ["h4"],
-            "2": ["b5"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        homerow: {
-          "1": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a8", "h8"]
-            }
-          ]
-        },
-        edges: [
-          {
-            rect: ["a1", "a8"]
-          },
-          {
-            rect: ["h1", "h8"]
-          },
-          {
-            rect: ["b8", "g8"]
-          },
-          {
-            rect: ["b1", "g1"]
-          }
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "h1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a8", "h8"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/gowiththefloe.js
+++ b/modules/logic/generated/gowiththefloe.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/gowiththefloe/boards";
+import setups from "../../games/definitions/gowiththefloe/setups";
+import variants from "../../games/definitions/gowiththefloe/variants";
 const emptyObj = {};
 const iconMapping = { seals: "king", bears: "queen", holes: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1139,75 +1142,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "s",
-      arr: {
-        marks: ["c7"],
-        potentialMarks: ["a5", "c5", "e5", "c6", "d6", "c8", "d8"],
-        setup: {
-          holes: {
-            "0": [
-              "b2",
-              "g2",
-              "c3",
-              "f3",
-              "b4",
-              "c4",
-              "d4",
-              "b6",
-              "b7",
-              "d7",
-              "e7",
-              "f7",
-              "g7"
-            ]
-          },
-          seals: {
-            "1": ["d2", "b5"]
-          },
-          bears: {
-            "2": ["e4", "c7"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {
-        water: [
-          "a1",
-          "a2",
-          "a7",
-          "a8",
-          "b1",
-          "b8",
-          "g1",
-          "g8",
-          "h1",
-          "h2",
-          "h7",
-          "h8"
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      seals: {
-        "1": ["b2", "b7"]
-      },
-      bears: {
-        "2": ["g2", "g7"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/hippolyta.js
+++ b/modules/logic/generated/hippolyta.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/hippolyta/boards";
+import setups from "../../games/definitions/hippolyta/setups";
+import variants from "../../games/definitions/hippolyta/variants";
 const emptyObj = {};
 const iconMapping = { amazons: "queen", projectile: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -349,119 +352,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          amazons: {
-            "1": [
-              {
-                rect: ["a8", "h8"]
-              },
-              {
-                rect: ["h2", "h7"]
-              },
-              {
-                rect: ["b2", "g2"]
-              },
-              {
-                rect: ["b3", "b6"]
-              },
-              {
-                rect: ["c6", "f6"]
-              },
-              "f5",
-              "f4",
-              "e4",
-              "d4"
-            ],
-            "2": [
-              {
-                rect: ["a1", "h1"]
-              },
-              {
-                rect: ["a2", "a7"]
-              },
-              {
-                rect: ["b7", "g7"]
-              },
-              {
-                rect: ["g3", "g6"]
-              },
-              {
-                rect: ["c3", "f3"]
-              },
-              "c4",
-              "c5",
-              "d5",
-              "e5"
-            ]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 8,
-      width: 8,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      amazons: {
-        "1": [
-          {
-            rect: ["a8", "h8"]
-          },
-          {
-            rect: ["h2", "h7"]
-          },
-          {
-            rect: ["b2", "g2"]
-          },
-          {
-            rect: ["b3", "b6"]
-          },
-          {
-            rect: ["c6", "f6"]
-          },
-          "f5",
-          "f4",
-          "e4",
-          "d4"
-        ],
-        "2": [
-          {
-            rect: ["a1", "h1"]
-          },
-          {
-            rect: ["a2", "a7"]
-          },
-          {
-            rect: ["b7", "g7"]
-          },
-          {
-            rect: ["g3", "g6"]
-          },
-          {
-            rect: ["c3", "f3"]
-          },
-          "c4",
-          "c5",
-          "d5",
-          "e5"
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/hobbes.js
+++ b/modules/logic/generated/hobbes.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/hobbes/boards";
+import setups from "../../games/definitions/hobbes/setups";
+import variants from "../../games/definitions/hobbes/variants";
 const emptyObj = {};
 const iconMapping = { stones: "pawn", kings: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1308,54 +1311,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          kings: {
-            "1": ["d2"],
-            "2": ["b4"]
-          },
-          stones: {
-            "0": ["a4", "b1", "b2", "b5", "c2", "c3", "d3", "d4", "d5", "e1"]
-          }
-        },
-        marks: [],
-        potentialMarks: ["c1", "c2", "d1", "d3", "e2", "e4", "e5"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        pie: ["c2"]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      stones: {
-        "0": [
-          {
-            holerect: ["b1", "d2", "c1"]
-          },
-          {
-            holerect: ["b4", "d5", "c5"]
-          }
-        ]
-      },
-      kings: {
-        "1": ["c1"],
-        "2": ["c5"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/jostle.js
+++ b/modules/logic/generated/jostle.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/jostle/boards";
+import setups from "../../games/definitions/jostle/setups";
+import variants from "../../games/definitions/jostle/variants";
 const emptyObj = {};
 const iconMapping = { checkers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -573,107 +576,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "w",
-      arr: {
-        marks: [],
-        potentialMarks: ["f3", "h5", "c6", "g6", "i6", "e8"],
-        setup: {
-          checkers: {
-            "1": [
-              "f3",
-              "h3",
-              "c4",
-              "d4",
-              "h4",
-              "d5",
-              "e5",
-              "h5",
-              "c6",
-              "f6",
-              "g6",
-              "i6",
-              "e7",
-              "b8",
-              "e8",
-              "g8"
-            ],
-            "2": [
-              "g2",
-              "d3",
-              "e3",
-              "e4",
-              "f4",
-              "i4",
-              "c5",
-              "g5",
-              "d6",
-              "e6",
-              "c7",
-              "f7",
-              "h7",
-              "d8",
-              "f8",
-              "h9"
-            ]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 10,
-      width: 10,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      checkers: {
-        "1": [
-          "c4",
-          "c6",
-          "c8",
-          "d3",
-          "d5",
-          "d7",
-          "e4",
-          "e8",
-          "f3",
-          "f7",
-          "g4",
-          "g6",
-          "g8",
-          "h3",
-          "h5",
-          "h7"
-        ],
-        "2": [
-          "c3",
-          "c5",
-          "c7",
-          "d4",
-          "d6",
-          "d8",
-          "e3",
-          "e7",
-          "f4",
-          "f8",
-          "g3",
-          "g5",
-          "g7",
-          "h4",
-          "h6",
-          "h8"
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/kachitknight.js
+++ b/modules/logic/generated/kachitknight.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/kachitknight/boards";
+import setups from "../../games/definitions/kachitknight/setups";
+import variants from "../../games/definitions/kachitknight/variants";
 const emptyObj = {};
 const iconMapping = {
   leader: "pawn",
@@ -1344,59 +1347,8 @@ const game = {
           });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          leader: {
-            "2": ["a4"]
-          },
-          leaderortho: {
-            "1": ["c3"]
-          },
-          knightortho: {
-            "1": ["d3"],
-            "2": ["a2", "b4"]
-          },
-          knightdiag: {
-            "1": ["c2"],
-            "2": ["b3"]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 4,
-      width: 4,
-      terrain: {
-        base: {
-          "1": ["b1", "c1", "c2", "d2", "d3"],
-          "2": ["a2", "a3", "b3", "b4", "c4"]
-        },
-        throne: {
-          "1": ["d1"],
-          "2": ["a4"]
-        },
-        promotion: ["a1", "b2", "c3", "d4"]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      leader: {
-        "1": ["d1"],
-        "2": ["a4"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/kickrun.js
+++ b/modules/logic/generated/kickrun.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/kickrun/boards";
+import setups from "../../games/definitions/kickrun/setups";
+import variants from "../../games/definitions/kickrun/variants";
 const emptyObj = {};
 const iconMapping = { runners: "bishop", sidekickers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -582,52 +585,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "m",
-      arr: {
-        marks: ["e3"],
-        potentialMarks: ["c1", "e1", "d2", "e2", "d3"],
-        setup: {
-          sidekickers: {
-            "1": ["b1", "d1", "b3"],
-            "2": ["c3", "c4", "e4"]
-          },
-          runners: {
-            "1": ["c2", "c5"],
-            "2": ["e3", "d5"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        corners: {
-          "1": ["a1"],
-          "2": ["e5"]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      runners: {
-        "1": ["a2", "b1"],
-        "2": ["d5", "e4"]
-      },
-      sidekickers: {
-        "1": ["a1", "c1", "a3"],
-        "2": ["c5", "e5", "e3"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/kingsvalley.js
+++ b/modules/logic/generated/kingsvalley.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/kingsvalley/boards";
+import setups from "../../games/definitions/kingsvalley/setups";
+import variants from "../../games/definitions/kingsvalley/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn", kings: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -583,92 +586,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        marks: ["c1"],
-        potentialMarks: ["b1", "b2", "c4", "e3"],
-        setup: {
-          soldiers: {
-            "1": ["a1", "b4", "d1", "d4"],
-            "2": ["a3", "a5", "d5", "e5"]
-          },
-          kings: {
-            "1": ["c5"],
-            "2": ["c1"]
-          }
-        }
-      }
-    },
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "retrieve",
-      desc: "retrieve",
-      code: "e"
-    },
-    {
-      ruleset: "basic",
-      board: "labyrinth",
-      setup: "labyrinth",
-      desc: "labyrinth",
-      code: "k"
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        goal: ["c3"],
-        water: []
-      }
-    },
-    labyrinth: {
-      height: 7,
-      width: 7,
-      terrain: {
-        goal: ["d4"],
-        water: ["b3", "b5", "f3", "f5"]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      kings: {
-        "1": ["c1"],
-        "2": ["c5"]
-      },
-      soldiers: {
-        "1": ["a1", "b1", "d1", "e1"],
-        "2": ["a5", "b5", "d5", "e5"]
-      }
-    },
-    retrieve: {
-      kings: {
-        "1": ["c5"],
-        "2": ["c1"]
-      },
-      soldiers: {
-        "1": ["a1", "b1", "d1", "e1"],
-        "2": ["a5", "b5", "d5", "e5"]
-      }
-    },
-    labyrinth: {
-      kings: {
-        "1": ["d7"],
-        "2": ["d1"]
-      },
-      soldiers: {
-        "1": ["a1", "b1", "c1", "e1", "f1", "g1"],
-        "2": ["a7", "b7", "c7", "e7", "f7", "g7"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/krieg.js
+++ b/modules/logic/generated/krieg.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/krieg/boards";
+import setups from "../../games/definitions/krieg/setups";
+import variants from "../../games/definitions/krieg/variants";
 const emptyObj = {};
 const iconMapping = { notfrozens: "pawn", frozens: "rook" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -657,54 +660,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "j",
-      arr: {
-        marks: ["a3"],
-        potentialMarks: ["a2", "a4"],
-        setup: {
-          notfrozens: {
-            "1": ["a3", "c3", "b4"],
-            "2": ["b1", "d1", "c2"]
-          },
-          frozens: {
-            "1": ["b3"],
-            "2": ["d3"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      width: 4,
-      height: 4,
-      terrain: {
-        southeast: ["a4", "c2"],
-        northwest: ["b3", "d1"],
-        corners: {
-          "1": ["a4"],
-          "2": ["d1"]
-        },
-        bases: {
-          "1": ["b4", "a3", "b3"],
-          "2": ["c2", "d2", "c1"]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      notfrozens: {
-        "1": ["a4", "b4", "a3", "b3"],
-        "2": ["c2", "c1", "d2", "d1"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/madbishops.js
+++ b/modules/logic/generated/madbishops.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/madbishops/boards";
+import setups from "../../games/definitions/madbishops/setups";
+import variants from "../../games/definitions/madbishops/variants";
 const emptyObj = {};
 const iconMapping = { bishops: "bishop" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -539,130 +542,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          bishops: {
-            "1": [
-              "a1",
-              "a5",
-              "b6",
-              "b8",
-              "c3",
-              "c7",
-              "c9",
-              "d10",
-              "e1",
-              "e7",
-              "f8",
-              "g3",
-              "g9",
-              "h10",
-              "i1",
-              "i3",
-              "i5",
-              "i7",
-              "j4",
-              "j8"
-            ],
-            "2": [
-              "a3",
-              "a7",
-              "b10",
-              "c5",
-              "d6",
-              "d8",
-              "e9",
-              "f4",
-              "f10",
-              "g1",
-              "g5",
-              "h4",
-              "h8",
-              "i9",
-              "j2",
-              "j6",
-              "j10"
-            ]
-          }
-        },
-        marks: ["h8"],
-        potentialMarks: ["c3", "g9", "i7"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 10,
-      width: 10,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      bishops: {
-        "1": [
-          "a1",
-          "a5",
-          "a9",
-          "b2",
-          "b6",
-          "c3",
-          "c7",
-          "c9",
-          "d4",
-          "d10",
-          "e1",
-          "e5",
-          "e7",
-          "f2",
-          "f8",
-          "g3",
-          "g5",
-          "g9",
-          "h6",
-          "h10",
-          "i1",
-          "i3",
-          "i7",
-          "j4",
-          "j8"
-        ],
-        "2": [
-          "a3",
-          "a7",
-          "b4",
-          "b8",
-          "b10",
-          "c1",
-          "c5",
-          "d2",
-          "d6",
-          "d8",
-          "e3",
-          "e9",
-          "f4",
-          "f6",
-          "f10",
-          "g1",
-          "g7",
-          "h2",
-          "h4",
-          "h8",
-          "i5",
-          "i9",
-          "j2",
-          "j6",
-          "j10"
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/momentum.js
+++ b/modules/logic/generated/momentum.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/momentum/boards";
+import setups from "../../games/definitions/momentum/setups";
+import variants from "../../games/definitions/momentum/variants";
 const emptyObj = {};
 const iconMapping = { stones: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -701,72 +704,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "k",
-      arr: {
-        marks: [],
-        potentialMarks: [
-          "b1",
-          "d1",
-          "f1",
-          "g1",
-          "b2",
-          "c2",
-          "d2",
-          "e2",
-          "f2",
-          "g2",
-          "a3",
-          "b3",
-          "d3",
-          "f3",
-          "g3",
-          "b4",
-          "d4",
-          "e4",
-          "f4",
-          "g4",
-          "a5",
-          "b5",
-          "c5",
-          "d5",
-          "f5",
-          "g5",
-          "a6",
-          "d6",
-          "e6",
-          "f6",
-          "a7",
-          "b7",
-          "c7",
-          "d7",
-          "e7",
-          "f7",
-          "g7"
-        ],
-        setup: {
-          stones: {
-            "1": ["a1", "c1", "e1", "c4", "b6", "c6"],
-            "2": ["a2", "c3", "e3", "a4", "e5", "g6"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 7,
-      width: 7,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/murusgallicus.js
+++ b/modules/logic/generated/murusgallicus.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/murusgallicus/boards";
+import setups from "../../games/definitions/murusgallicus/setups";
+import variants from "../../games/definitions/murusgallicus/variants";
 const emptyObj = {};
 const iconMapping = { towers: "rook", walls: "pawn", catapults: "queen" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -3334,89 +3337,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "x",
-      arr: {
-        marks: ["c3"],
-        potentialMarks: ["e3", "a5", "e5"],
-        setup: {
-          towers: {
-            "1": ["e1", "g1", "h1", "b2", "c2", "b3", "c3"],
-            "2": ["f5", "b6", "g6", "c7", "d7", "e7"]
-          },
-          walls: {
-            "1": ["e2", "d3"],
-            "2": ["b5", "c5", "g5", "f6"]
-          }
-        }
-      }
-    },
-    {
-      ruleset: "advanced",
-      board: "basic",
-      setup: "basic",
-      desc: "advanced",
-      code: "k",
-      arr: {
-        marks: ["c3"],
-        potentialMarks: ["a3", "a5", "c5", "e5", "c6", "f6"],
-        setup: {
-          towers: {
-            "1": ["g1", "d3", "c4"],
-            "2": ["d5", "e5", "b6", "f6", "g6"]
-          },
-          walls: {
-            "1": ["g2", "e3", "f3", "b4"],
-            "2": ["d4", "b5", "c5"]
-          },
-          catapults: {
-            "1": ["b3", "c3"],
-            "2": ["f5"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 7,
-      width: 8,
-      terrain: {
-        homerow: {
-          "1": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a7", "h7"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      towers: {
-        "1": [
-          {
-            rect: ["a1", "h1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a7", "h7"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/neutron.js
+++ b/modules/logic/generated/neutron.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/neutron/boards";
+import setups from "../../games/definitions/neutron/setups";
+import variants from "../../games/definitions/neutron/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1729,113 +1732,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          soldiers: {
-            "0": ["a3"],
-            "1": ["a4", "b4", "b3", "c1", "e1"],
-            "2": ["a1", "a5", "c5", "d5", "e2"]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    },
-    {
-      ruleset: "paperneutron",
-      board: "paperneutron",
-      setup: "paperneutron",
-      desc: "paper neutron",
-      code: "p",
-      arr: {
-        setup: {
-          soldiers: {
-            "0": ["a2", "d2"],
-            "1": ["a1", "b1", "c3", "d3"],
-            "2": ["a4", "b2", "c4", "d4"]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "e1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a5", "e5"]
-            }
-          ]
-        }
-      }
-    },
-    paperneutron: {
-      height: 4,
-      width: 4,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "d1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a4", "d4"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "0": ["c3"],
-        "1": [
-          {
-            rect: ["a1", "e1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a5", "e5"]
-          }
-        ]
-      }
-    },
-    paperneutron: {
-      soldiers: {
-        "0": ["b3", "c2"],
-        "1": [
-          {
-            rect: ["a1", "d1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a4", "d4"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/orthokon.js
+++ b/modules/logic/generated/orthokon.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/orthokon/boards";
+import setups from "../../games/definitions/orthokon/setups";
+import variants from "../../games/definitions/orthokon/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -489,47 +492,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "e",
-      arr: {
-        marks: ["c1"],
-        potentialMarks: ["a1", "d1", "b2", "d2", "c3"],
-        setup: {
-          soldiers: {
-            "1": ["c1", "b3", "b4", "d4"],
-            "2": ["a2", "a3", "a4", "c4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 4,
-      width: 4,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "d1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a4", "d4"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/scatter.js
+++ b/modules/logic/generated/scatter.js
@@ -16,6 +16,9 @@ import {
   ringTwoDirs,
   makeGrids
 } from "../../common";
+import boards from "../../games/definitions/scatter/boards";
+import setups from "../../games/definitions/scatter/setups";
+import variants from "../../games/definitions/scatter/variants";
 const emptyObj = {};
 const iconMapping = { pawns: "pawn", nobles: "king", kings: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions, GRIDS;
@@ -1153,92 +1156,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          kings: {
-            "0": ["e1", "e2", "f1", "f2"]
-          },
-          pawns: {
-            "1": ["b1", "c2", "d1", "e4", "b6", "c5", "d5", "d6"],
-            "2": ["a3", "a4", "b2", "b4", "c3", "c4", "d4", "e3"]
-          }
-        },
-        marks: ["b4"],
-        potentialMarks: ["b3", "b5"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 6,
-      width: 6,
-      terrain: {
-        odd: [
-          {
-            holerect: ["a5", "f6", "c5", "c6", "d5", "d6"]
-          },
-          {
-            holerect: ["a1", "f2", "c1", "c2", "d1", "d2"]
-          },
-          {
-            rect: ["c3", "d4"]
-          }
-        ]
-      },
-      offsets: [
-        ["ortho", 2, 0],
-        ["ortho", 2, -1],
-        ["ortho", 2, 1],
-        ["ortho", 3, 0],
-        ["ortho", 3, 1],
-        ["ortho", 3, -1]
-      ],
-      grids: {
-        binary: [
-          [1, 1, 2, 2, 4, 4],
-          [1, 1, 2, 2, 4, 4],
-          [8, 8, 16, 16, 32, 32],
-          [8, 8, 16, 16, 32, 32],
-          [64, 64, 128, 128, 256, 256],
-          [64, 64, 128, 128, 256, 256]
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      nobles: {
-        "0": ["c3", "d3", "d4"]
-      },
-      kings: {
-        "0": ["c4"]
-      },
-      pawns: {
-        "1": [
-          {
-            rect: ["c1", "d2"]
-          },
-          {
-            rect: ["c5", "d6"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a3", "b4"]
-          },
-          {
-            rect: ["e3", "f4"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/serauqs.js
+++ b/modules/logic/generated/serauqs.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/serauqs/boards";
+import setups from "../../games/definitions/serauqs/setups";
+import variants from "../../games/definitions/serauqs/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn", wild: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -708,70 +711,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "c",
-      arr: {
-        marks: ["b3"],
-        potentialMarks: ["a2", "c2", "b4", "c4"],
-        setup: {
-          soldiers: {
-            "1": ["b1", "a3", "b3"],
-            "2": ["b2", "c3", "d3"]
-          },
-          wild: {
-            "1": ["c1"],
-            "2": ["a4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 4,
-      width: 4,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "d1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a4", "d4"]
-            }
-          ]
-        },
-        corners: ["a1", "a4", "d1", "d4"],
-        middle: [
-          {
-            rect: ["b2", "c3"]
-          }
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "d1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a4", "d4"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/shoveoff.js
+++ b/modules/logic/generated/shoveoff.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/shoveoff/boards";
+import setups from "../../games/definitions/shoveoff/setups";
+import variants from "../../games/definitions/shoveoff/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1313,69 +1316,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "a",
-      arr: {
-        marks: [],
-        potentialMarks: ["a1", "c1", "d1", "d2", "a3", "a4", "b4", "c4", "d4"],
-        setup: {
-          soldiers: {
-            "0": ["c1", "a2", "b2", "d3", "a4", "c4"],
-            "1": ["a1", "d2", "a3", "c3", "b4"],
-            "2": ["b1", "d1", "c2", "b3", "d4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 4,
-      width: 4,
-      terrain: {
-        southedge: [
-          {
-            rect: ["a1", "d1"]
-          }
-        ],
-        northedge: [
-          {
-            rect: ["a4", "d4"]
-          }
-        ],
-        westedge: [
-          {
-            rect: ["a1", "a4"]
-          }
-        ],
-        eastedge: [
-          {
-            rect: ["d1", "d4"]
-          }
-        ],
-        edge: [
-          {
-            holerect: ["a1", "d4", "b2", "b3", "c2", "c3"]
-          }
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "0": [
-          {
-            rect: ["a1", "d4"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/speedsoccolot.js
+++ b/modules/logic/generated/speedsoccolot.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/speedsoccolot/boards";
+import setups from "../../games/definitions/speedsoccolot/setups";
+import variants from "../../games/definitions/speedsoccolot/variants";
 const emptyObj = {};
 const iconMapping = { ball: "pawn", players: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1156,113 +1159,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "speed",
-      code: "r",
-      arr: {
-        setup: {
-          ball: {
-            "0": ["e3"]
-          },
-          players: {
-            "1": ["b2", "c2", "d1", "f2", "f3"],
-            "2": ["c3", "c6", "d6", "e6", "f5"]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    },
-    {
-      ruleset: "basic",
-      board: "original",
-      setup: "original",
-      desc: "original",
-      code: "o",
-      arr: {
-        setup: {},
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    original: {
-      height: 8,
-      width: 8,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "h1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a8", "h8"]
-            }
-          ]
-        }
-      }
-    },
-    basic: {
-      height: 7,
-      width: 7,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "g1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a7", "g7"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    original: {
-      ball: {
-        "0": ["d4"]
-      },
-      players: {
-        "1": [
-          {
-            rect: ["b1", "g1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["b8", "g8"]
-          }
-        ]
-      }
-    },
-    basic: {
-      ball: {
-        "0": ["d4"]
-      },
-      players: {
-        "1": [
-          {
-            rect: ["b2", "f2"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["b6", "f6"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/squava.js
+++ b/modules/logic/generated/squava.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/squava/boards";
+import setups from "../../games/definitions/squava/setups";
+import variants from "../../games/definitions/squava/variants";
 const emptyObj = {};
 const iconMapping = { markers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -471,34 +474,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          markers: {
-            "1": ["b2", "b4", "b5", "c4", "e2"],
-            "2": ["a1", "c3", "d3", "d4"]
-          }
-        },
-        marks: ["b3"],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/stooges.js
+++ b/modules/logic/generated/stooges.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/stooges/boards";
+import setups from "../../games/definitions/stooges/setups";
+import variants from "../../games/definitions/stooges/variants";
 const emptyObj = {};
 const iconMapping = { singles: "pawn", doubles: "rook" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -761,62 +764,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          singles: {
-            "1": ["a3", "c1", "c5", "e2"],
-            "2": ["b2", "b3", "c2", "d1", "d2", "d5", "e3", "e4"]
-          },
-          doubles: {
-            "1": ["b4", "c3", "d4"],
-            "2": ["c4", "d3", "f3"]
-          }
-        },
-        marks: ["d3"],
-        potentialMarks: ["c2", "d2", "e3", "e4"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 6,
-      terrain: {
-        corners: [
-          "a1",
-          "a2",
-          "b1",
-          "a4",
-          "a5",
-          "b5",
-          "e1",
-          "f1",
-          "f2",
-          "e5",
-          "f4",
-          "f5"
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      singles: {
-        "1": ["b2", "b4", "c1", "c5", "d2", "d4"],
-        "2": ["c2", "c4", "d1", "d5", "e2", "e4"]
-      },
-      doubles: {
-        "1": ["a3", "c3", "e3"],
-        "2": ["b3", "d3", "f3"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/threemusketeers.js
+++ b/modules/logic/generated/threemusketeers.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/threemusketeers/boards";
+import setups from "../../games/definitions/threemusketeers/setups";
+import variants from "../../games/definitions/threemusketeers/variants";
 const emptyObj = {};
 const iconMapping = { pawns: "pawn", kings: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -480,65 +483,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "t",
-      arr: {
-        marks: ["c3"],
-        potentialMarks: ["c2", "d3", "c4"],
-        setup: {
-          pawns: {
-            "2": [
-              "a1",
-              "b1",
-              "c1",
-              "d1",
-              "e1",
-              "c2",
-              "d2",
-              "e2",
-              "a3",
-              "d3",
-              "e3",
-              "a4",
-              "b4",
-              "c4",
-              "a5",
-              "c5",
-              "d5"
-            ]
-          },
-          kings: {
-            "1": ["b2", "c3", "e4"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      kings: {
-        "1": ["a1", "c3", "e5"]
-      },
-      pawns: {
-        "2": [
-          {
-            holerect: ["a1", "e5", "a1", "c3", "e5"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/tobito.js
+++ b/modules/logic/generated/tobito.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/tobito/boards";
+import setups from "../../games/definitions/tobito/setups";
+import variants from "../../games/definitions/tobito/variants";
 const emptyObj = {};
 const iconMapping = { runners: "pawn", finishers: "rook" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1294,61 +1297,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          runners: {
-            "1": ["a1", "c3", "d1"],
-            "2": ["d3", "e2"]
-          },
-          finishers: {
-            "2": ["a3"]
-          }
-        },
-        marks: ["c3"],
-        potentialMarks: ["b2", "b3", "c2", "d2", "e3"]
-      }
-    },
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "neutral",
-      desc: "with neutral unit",
-      code: "N"
-    }
-  ],
-  boards: {
-    basic: {
-      height: 3,
-      width: 5,
-      terrain: {
-        base: {
-          "1": ["a1", "a2", "a3"],
-          "2": ["e1", "e2", "e3"]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      runners: {
-        "1": ["a1", "a2", "a3"],
-        "2": ["e1", "e2", "e3"]
-      }
-    },
-    neutral: {
-      runners: {
-        "0": ["c2"],
-        "1": ["a1", "a2", "a3"],
-        "2": ["e1", "e2", "e3"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/trafficlights.js
+++ b/modules/logic/generated/trafficlights.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/trafficlights/boards";
+import setups from "../../games/definitions/trafficlights/setups";
+import variants from "../../games/definitions/trafficlights/variants";
 const emptyObj = {};
 const iconMapping = { kings: "king", pawns: "pawn", bishops: "bishop" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -618,51 +621,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "b",
-      arr: {
-        marks: [],
-        potentialMarks: [
-          "a1",
-          "b1",
-          "c1",
-          "d1",
-          "a2",
-          "b2",
-          "d2",
-          "a3",
-          "b3",
-          "c3",
-          "d3"
-        ],
-        setup: {
-          bishops: {
-            "0": ["b1", "b2"]
-          },
-          pawns: {
-            "0": ["a2", "c3"]
-          },
-          kings: {
-            "0": ["c2"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      width: 4,
-      height: 3,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/transet.js
+++ b/modules/logic/generated/transet.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/transet/boards";
+import setups from "../../games/definitions/transet/setups";
+import variants from "../../games/definitions/transet/variants";
 const emptyObj = {};
 const iconMapping = { pinets: "pawn", piokers: "bishop", piases: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1225,68 +1228,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        marks: ["c5"],
-        potentialMarks: ["d3", "a4", "b4", "c4", "d4", "b5"],
-        setup: {
-          piokers: {
-            "1": ["b1", "e2"],
-            "2": ["d3", "b5"]
-          },
-          pinets: {
-            "1": ["e1", "a2"],
-            "2": ["a4", "e5"]
-          },
-          piases: {
-            "1": ["c3"],
-            "2": ["c5"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "e1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a5", "e5"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      pinets: {
-        "1": ["a1", "e1"],
-        "2": ["a5", "e5"]
-      },
-      piokers: {
-        "1": ["b1", "d1"],
-        "2": ["b5", "d5"]
-      },
-      piases: {
-        "1": ["c1"],
-        "2": ["c5"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/tunneler.js
+++ b/modules/logic/generated/tunneler.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/tunneler/boards";
+import setups from "../../games/definitions/tunneler/setups";
+import variants from "../../games/definitions/tunneler/variants";
 const emptyObj = {};
 const iconMapping = { foremen: "king", tunnelers: "rook", rocks: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -670,131 +673,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          rocks: {
-            "0": [
-              {
-                holerect: [
-                  "a1",
-                  "k11",
-                  "c2",
-                  "e2",
-                  "g2",
-                  "h2",
-                  "i2",
-                  "g3",
-                  "i3",
-                  "d4",
-                  "e4",
-                  "g4",
-                  "h4",
-                  "i4",
-                  "j4",
-                  "k4",
-                  "c5",
-                  "d5",
-                  "i5",
-                  "k5",
-                  "c6",
-                  "e6",
-                  "f6",
-                  "g6",
-                  "h6",
-                  "i6",
-                  "k6",
-                  "b7",
-                  "c7",
-                  "e7",
-                  "k7",
-                  "b8",
-                  "e8",
-                  "g8",
-                  "h8",
-                  "i8",
-                  "k8",
-                  "b9",
-                  "c9",
-                  "g9",
-                  "i9",
-                  "j9",
-                  "k9",
-                  "c10",
-                  "e10",
-                  "g10",
-                  "i10",
-                  "c11",
-                  "d11",
-                  "e11",
-                  "f11",
-                  "g11",
-                  "h11",
-                  "i11"
-                ]
-              }
-            ]
-          },
-          foremen: {
-            "1": ["c2", "h2"],
-            "2": ["i8", "i10"]
-          },
-          tunnelers: {
-            "1": ["e2", "g3", "j9"],
-            "2": ["e10", "g11", "i3"]
-          }
-        },
-        marks: ["i3"],
-        potentialMarks: ["i2", "i1", "i4", "i5", "i6", "i7"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 11,
-      width: 11,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      foremen: {
-        "1": ["c2", "i2"],
-        "2": ["c10", "i10"]
-      },
-      tunnelers: {
-        "1": ["e2", "e4", "g4", "g2"],
-        "2": ["e10", "e8", "g8", "g10"]
-      },
-      rocks: {
-        "0": [
-          {
-            holerect: [
-              "a1",
-              "k11",
-              "c2",
-              "i2",
-              "c10",
-              "i10",
-              "e2",
-              "e4",
-              "g4",
-              "g2",
-              "e10",
-              "e8",
-              "g8",
-              "g10"
-            ]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/tyrannos.js
+++ b/modules/logic/generated/tyrannos.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/tyrannos/boards";
+import setups from "../../games/definitions/tyrannos/setups";
+import variants from "../../games/definitions/tyrannos/variants";
 const emptyObj = {};
 const iconMapping = {
   warriors: "pawn",
@@ -742,93 +745,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          barricades: {
-            "1": ["e3"],
-            "2": ["e7"]
-          },
-          tyrannos: {
-            "1": ["e2"],
-            "2": ["e8"]
-          },
-          warriors: {
-            "1": [
-              {
-                holerect: ["a3", "i3", "e3"]
-              }
-            ],
-            "2": [
-              {
-                holerect: ["a7", "i7", "e7"]
-              }
-            ]
-          },
-          heroes: {
-            "1": ["a2", "b2", "c2", "g2", "h2", "i2"],
-            "2": ["a8", "b8", "c8", "g8", "h8", "i8"]
-          }
-        },
-        marks: ["c3"],
-        potentialMarks: ["b4", "c4", "d4"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 9,
-      width: 9,
-      terrain: {
-        base: {
-          "1": [
-            {
-              rect: ["a1", "i1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a9", "i9"]
-            }
-          ]
-        },
-        temple: ["e5"]
-      }
-    }
-  },
-  setups: {
-    basic: {
-      barricades: {
-        "1": ["e3"],
-        "2": ["e7"]
-      },
-      tyrannos: {
-        "1": ["e2"],
-        "2": ["e8"]
-      },
-      warriors: {
-        "1": [
-          {
-            holerect: ["a3", "i3", "e3"]
-          }
-        ],
-        "2": [
-          {
-            holerect: ["a7", "i7", "e7"]
-          }
-        ]
-      },
-      heroes: {
-        "1": ["a2", "b2", "c2", "g2", "h2", "i2"],
-        "2": ["a8", "b8", "c8", "g8", "h8", "i8"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/uglyduck.js
+++ b/modules/logic/generated/uglyduck.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/uglyduck/boards";
+import setups from "../../games/definitions/uglyduck/setups";
+import variants from "../../games/definitions/uglyduck/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn", kings: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -659,63 +662,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "y",
-      arr: {
-        marks: ["b4"],
-        potentialMarks: ["a3", "c3"],
-        setup: {
-          soldiers: {
-            "1": ["c1", "d1", "b2", "b3"],
-            "2": ["d3", "e3", "a4", "b4", "d5"]
-          },
-          kings: {
-            "1": ["c5"]
-          }
-        }
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        homerow: {
-          "1": [
-            {
-              rect: ["a1", "e1"]
-            }
-          ],
-          "2": [
-            {
-              rect: ["a5", "e5"]
-            }
-          ]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            rect: ["a1", "e1"]
-          }
-        ],
-        "2": [
-          {
-            rect: ["a5", "e5"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/uisge.js
+++ b/modules/logic/generated/uisge.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/uisge/boards";
+import setups from "../../games/definitions/uisge/setups";
+import variants from "../../games/definitions/uisge/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn", kings: "king" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -785,51 +788,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          kings: {
-            "1": ["b3", "c2"],
-            "2": ["b5"]
-          },
-          soldiers: {
-            "1": ["c3", "d2", "e3", "f3"],
-            "2": ["b4", "c4", "c5", "d4", "e4"]
-          }
-        },
-        marks: ["b5"],
-        potentialMarks: ["a4", "c6", "d5"]
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 6,
-      width: 7,
-      terrain: {}
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            holerect: ["c2", "f3", "c2", "f2"]
-          }
-        ],
-        "2": [
-          {
-            holerect: ["b4", "e5", "b5", "e5"]
-          }
-        ]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/yonmoque.js
+++ b/modules/logic/generated/yonmoque.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/yonmoque/boards";
+import setups from "../../games/definitions/yonmoque/setups";
+import variants from "../../games/definitions/yonmoque/variants";
 const emptyObj = {};
 const iconMapping = { pawns: "pawn", bishops: "bishop" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -1309,64 +1312,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          pawns: {
-            "1": ["b3", "c3", "c4"],
-            "2": ["a3"]
-          },
-          bishops: {
-            "1": ["d2", "e3"],
-            "2": ["b1", "d5"]
-          }
-        },
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 5,
-      width: 5,
-      terrain: {
-        base: {
-          "1": ["a3", "b2", "b4", "c1", "c5", "d2", "d4", "e3"],
-          "2": [
-            "a2",
-            "a4",
-            "b1",
-            "b3",
-            "b5",
-            "c2",
-            "c4",
-            "d1",
-            "d3",
-            "d5",
-            "e2",
-            "e4"
-          ]
-        },
-        edge: [
-          {
-            rect: ["a1", "a5"]
-          },
-          {
-            rect: ["b1", "e1"]
-          }
-        ]
-      }
-    }
-  },
-  setups: {
-    basic: {}
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;

--- a/modules/logic/generated/zonesh.js
+++ b/modules/logic/generated/zonesh.js
@@ -15,6 +15,9 @@ import {
   jumpTwoDirs,
   ringTwoDirs
 } from "../../common";
+import boards from "../../games/definitions/zonesh/boards";
+import setups from "../../games/definitions/zonesh/setups";
+import variants from "../../games/definitions/zonesh/variants";
 const emptyObj = {};
 const iconMapping = { soldiers: "pawn" };
 let TERRAIN1, TERRAIN2, connections, relativeDirs, BOARD, dimensions;
@@ -491,96 +494,8 @@ const game = {
       });
     }
   },
-  variants: [
-    {
-      ruleset: "basic",
-      board: "basic",
-      setup: "basic",
-      desc: "regular",
-      code: "r",
-      arr: {
-        setup: {
-          soldiers: {
-            "1": ["a1", "a2", "a3", "a5", "b1", "b2", "c2", "c3", "d1", "e1"],
-            "2": ["c5", "c6", "d5", "e3", "e4", "e6", "f3", "f4", "f5", "f6"]
-          }
-        },
-        marks: ["c3"],
-        potentialMarks: ["b3", "b4", "c4", "d2", "d3", "d4"]
-      }
-    },
-    {
-      ruleset: "basic",
-      board: "mini",
-      setup: "mini",
-      desc: "mini",
-      code: "m",
-      arr: {
-        setup: {},
-        marks: [],
-        potentialMarks: []
-      }
-    }
-  ],
-  boards: {
-    basic: {
-      height: 6,
-      width: 6,
-      terrain: {
-        throne: {
-          "1": ["a1"],
-          "2": ["f6"]
-        },
-        base: {
-          "1": [
-            {
-              holerect: ["a1", "d4", "a1", "b4", "c3", "c4", "d2", "d3", "d4"]
-            }
-          ],
-          "2": [
-            {
-              holerect: ["c3", "f6", "f6", "c3", "c4", "c5", "d3", "d4", "e3"]
-            }
-          ]
-        }
-      }
-    },
-    mini: {
-      height: 5,
-      width: 5,
-      terrain: {
-        throne: {
-          "1": ["a1"],
-          "2": ["e5"]
-        },
-        base: {
-          "1": ["a2", "a3", "b1", "b2", "c1"],
-          "2": ["c5", "d4", "d5", "e3", "e4"]
-        }
-      }
-    }
-  },
-  setups: {
-    basic: {
-      soldiers: {
-        "1": [
-          {
-            holerect: ["a1", "d4", "b4", "c3", "c4", "d2", "d3", "d4"]
-          }
-        ],
-        "2": [
-          {
-            holerect: ["c3", "f6", "c3", "c4", "c5", "d3", "d4", "e3"]
-          }
-        ]
-      }
-    },
-    mini: {
-      soldiers: {
-        "1": ["a1", "a2", "a3", "b1", "b2", "c1"],
-        "2": ["c5", "d4", "d5", "e3", "e4", "e5"]
-      }
-    }
-  }
+  variants,
+  boards,
+  setups
 };
 export default game;


### PR DESCRIPTION
Minor improvement to the compilation engine, linking static stuff from game definitions (setups, boards and variants) instead of copying them.

Means we have to run `npm process <game> compile` slightly less often when we add new games!