### PR TITLE
Fix sideways navigation

### DIFF
--- a/modules/common/nav/findShortcut.ts
+++ b/modules/common/nav/findShortcut.ts
@@ -1,6 +1,6 @@
-import { AlgolNav } from "../../types";
+import { AlgolNav, AlgolNavStep } from "../../types";
 
-export const findShortcut = (nav?: AlgolNav): string | null => {
+export const findShortcut = (nav?: AlgolNav): AlgolNavStep | null => {
   if (nav) {
     const {
       crumbs,
@@ -10,7 +10,7 @@ export const findShortcut = (nav?: AlgolNav): string | null => {
       const shortcut = crumbs[crumbs.length - 1].links.find(
         l => l.id === links[links.length - 1].id
       );
-      return shortcut ? shortcut.id : null;
+      return shortcut || null;
     }
   }
   return null;

--- a/modules/common/nav/findShortcut.ts
+++ b/modules/common/nav/findShortcut.ts
@@ -1,0 +1,17 @@
+import { AlgolNav } from "../../types";
+
+export const findShortcut = (nav?: AlgolNav): string | null => {
+  if (nav) {
+    const {
+      crumbs,
+      me: { links },
+    } = nav;
+    if (links.length && crumbs.length) {
+      const shortcut = crumbs[crumbs.length - 1].links.find(
+        l => l.id === links[links.length - 1].id
+      );
+      return shortcut ? shortcut.id : null;
+    }
+  }
+  return null;
+};

--- a/modules/common/nav/makeGameAboutStep.ts
+++ b/modules/common/nav/makeGameAboutStep.ts
@@ -1,11 +1,13 @@
 import { AlgolGameBlobAnon, AlgolMeta, AlgolNavStep } from "../../types";
+import { makeGameRulesStep } from "./makeGameRulesStep";
 
 export const makeGameAboutStep = (
-  meta: AlgolMeta<AlgolGameBlobAnon>
+  meta: AlgolMeta<AlgolGameBlobAnon>,
+  skinny?: boolean
 ): AlgolNavStep => ({
   id: `game-${meta.id}-info`,
   title: `Info`,
   desc: `All about ${meta.name}`,
   url: `/games/${meta.slug}/info`,
-  links: [],
+  links: !skinny ? [makeGameRulesStep(meta, true)] : [],
 });

--- a/modules/common/nav/makeGameRulesStep.ts
+++ b/modules/common/nav/makeGameRulesStep.ts
@@ -1,11 +1,13 @@
 import { AlgolGameBlobAnon, AlgolMeta, AlgolNavStep } from "../../types";
+import { makeGameAboutStep } from "./makeGameAboutStep";
 
 export const makeGameRulesStep = (
-  meta: AlgolMeta<AlgolGameBlobAnon>
+  meta: AlgolMeta<AlgolGameBlobAnon>,
+  skinny?: boolean
 ): AlgolNavStep => ({
   id: `game-${meta.id}-rules`,
   title: `Rules`,
   desc: `How to play ${meta.name}`,
   url: `/games/${meta.slug}/rules`,
-  links: [],
+  links: !skinny ? [makeGameAboutStep(meta, true)] : [],
 });

--- a/modules/common/nav/makeSessionControlsStep.ts
+++ b/modules/common/nav/makeSessionControlsStep.ts
@@ -1,4 +1,5 @@
 import { BattleNavActions, AlgolNavStep } from "../../types";
+import { makeSessionHistoryStep } from "./makeSessionHistoryStep";
 
 type MakeSessionControlsOpts = {
   battleNavActions: BattleNavActions;
@@ -8,7 +9,8 @@ type MakeSessionControlsOpts = {
 };
 
 export const makeSessionControlsStep = (
-  opts: MakeSessionControlsOpts
+  opts: MakeSessionControlsOpts,
+  naked?: boolean
 ): AlgolNavStep =>
   opts.isNew
     ? {
@@ -23,5 +25,5 @@ export const makeSessionControlsStep = (
         title: "Play",
         desc: "Make a move",
         onClick: opts.battleNavActions.toBattleControls,
-        links: [],
+        links: naked ? [] : [makeSessionHistoryStep(opts, true)],
       };

--- a/modules/common/nav/makeSessionHistoryStep.ts
+++ b/modules/common/nav/makeSessionHistoryStep.ts
@@ -1,4 +1,5 @@
 import { BattleNavActions, AlgolNavStep } from "../../types";
+import { makeSessionControlsStep } from "./makeSessionControlsStep";
 
 type MakeSessionHistoryOpts = {
   battleNavActions: BattleNavActions;
@@ -7,11 +8,12 @@ type MakeSessionHistoryOpts = {
 };
 
 export const makeSessionHistoryStep = (
-  opts: MakeSessionHistoryOpts
+  opts: MakeSessionHistoryOpts,
+  naked?: boolean
 ): AlgolNavStep => ({
   id: `game-${opts.gameId}-session-${opts.sessionId}-history`,
   title: "History",
   desc: "See previous moves in this session",
   onClick: opts.battleNavActions.toHistory,
-  links: [],
+  links: naked ? [] : [makeSessionControlsStep(opts, true)],
 });

--- a/modules/ui/src/components/Arrow/Arrow.Multi.tsx
+++ b/modules/ui/src/components/Arrow/Arrow.Multi.tsx
@@ -3,12 +3,12 @@ import classNames from "classnames";
 import css from "./Arrow.cssProxy";
 import { ArrowFlush, ArrowLayout, ArrowHead, Arrow } from "./Arrow";
 
-export type ArrowMulti = {
+export type ArrowMultiProps = {
   head?: ArrowHead;
   flush?: ArrowFlush;
 } & Partial<{ [layout in ArrowLayout]: boolean }>;
 
-export const ArrowMulti: FunctionComponent<ArrowMulti> = props => {
+export const ArrowMulti: FunctionComponent<ArrowMultiProps> = props => {
   const {
     head,
     flush,

--- a/modules/ui/src/components/Arrow/Arrow.css
+++ b/modules/ui/src/components/Arrow/Arrow.css
@@ -156,3 +156,10 @@
 .arrowFlushTop.arrowHeadWest:before {
   top: calc(var(--arrow-size) * -1);
 }
+
+.arrowDashed.arrowHeadNorth:before,
+.arrowDashed.arrowHeadEast:before,
+.arrowDashed.arrowHeadSouth:before,
+.arrowDashed.arrowHeadWest:before {
+  opacity: 0.5;
+}

--- a/modules/ui/src/components/Arrow/Arrow.css
+++ b/modules/ui/src/components/Arrow/Arrow.css
@@ -42,6 +42,13 @@
   width: 100%;
 }
 
+.arrowDashed:after {
+  border-style: dashed;
+}
+.arrowDashed:before {
+  border-style: dashed;
+}
+
 .arrowNorthSouth:after {
   border-left-width: 1px;
   align-self: flex-end;

--- a/modules/ui/src/components/Arrow/Arrow.tsx
+++ b/modules/ui/src/components/Arrow/Arrow.tsx
@@ -10,6 +10,7 @@ export type ArrowProps = {
   layout: ArrowLayout;
   head?: ArrowHead;
   flush?: ArrowFlush;
+  dashed?: boolean;
 };
 
 const layoutClassMap = {
@@ -41,14 +42,15 @@ export const arrowFlush = ["none"].concat(
 ) as ArrowFlush[];
 
 export const Arrow: FunctionComponent<ArrowProps> = props => {
-  const { layout, head, flush } = props;
+  const { layout, head, flush, dashed } = props;
   return (
     <div
       className={classNames(
         css.arrowContainer,
         layoutClassMap[layout],
         head && headClassMap[head],
-        flush && flushClassMap[flush]
+        flush && flushClassMap[flush],
+        dashed && css.arrowDashed
       )}
     ></div>
   );

--- a/modules/ui/src/components/Nav/Nav.BetweenRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BetweenRow.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React, { FunctionComponent } from "react";
 import css from "./Nav.cssProxy";
 import { Arrow } from "../Arrow";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 type NavBetweenRowProps = {
   hasBack?: boolean;
@@ -14,13 +15,13 @@ export const NavBetweenRow: FunctionComponent<NavBetweenRowProps> = ({
 }) => (
   <div className={classNames(css.navRow, css.navBetweenRow)}>
     <div className={css.navSideButtonContainer}>
-      {hasBack && <Arrow layout="northsouth" />}
+      {hasBack && <Arrow layout="northsouth" dashed={DASHED_SHORTCUTS} />}
     </div>
     <div className={css.navSideButtonContainer}>
       <Arrow layout="northsouth" head="south" />
     </div>
     <div className={css.navSideButtonContainer}>
-      {hasShort && <Arrow layout="northsouth" />}
+      {hasShort && <Arrow layout="northsouth" dashed={DASHED_SHORTCUTS} />}
     </div>
   </div>
 );

--- a/modules/ui/src/components/Nav/Nav.BetweenRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BetweenRow.tsx
@@ -5,10 +5,12 @@ import { Arrow } from "../Arrow";
 
 type NavBetweenRowProps = {
   hasBack?: boolean;
+  hasShort?: boolean;
 };
 
 export const NavBetweenRow: FunctionComponent<NavBetweenRowProps> = ({
   hasBack,
+  hasShort,
 }) => (
   <div className={classNames(css.navRow, css.navBetweenRow)}>
     <div className={css.navSideButtonContainer}>
@@ -17,7 +19,9 @@ export const NavBetweenRow: FunctionComponent<NavBetweenRowProps> = ({
     <div className={css.navSideButtonContainer}>
       <Arrow layout="northsouth" head="south" />
     </div>
-    <div className={css.navSideButtonContainer} />
+    <div className={css.navSideButtonContainer}>
+      {hasShort && <Arrow layout="northsouth" />}
+    </div>
   </div>
 );
 

--- a/modules/ui/src/components/Nav/Nav.BetweenRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BetweenRow.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import React, { FunctionComponent } from "react";
 import css from "./Nav.cssProxy";
 import { Arrow } from "../Arrow";
-import { DASHED_SHORTCUTS } from "./Nav.constants";
+import { DASHED_SHORTCUTS, SHORTCUT_STRATEGY } from "./Nav.constants";
 
 type NavBetweenRowProps = {
   hasBack?: boolean;
@@ -21,7 +21,12 @@ export const NavBetweenRow: FunctionComponent<NavBetweenRowProps> = ({
       <Arrow layout="northsouth" head="south" />
     </div>
     <div className={css.navSideButtonContainer}>
-      {hasShort && <Arrow layout="northsouth" dashed={DASHED_SHORTCUTS} />}
+      {hasShort && (
+        <Arrow
+          layout="northsouth"
+          dashed={DASHED_SHORTCUTS && SHORTCUT_STRATEGY === "top"}
+        />
+      )}
     </div>
   </div>
 );

--- a/modules/ui/src/components/Nav/Nav.Bottom.css
+++ b/modules/ui/src/components/Nav/Nav.Bottom.css
@@ -36,17 +36,25 @@
   transform: translate3d(-100px, 0, 0);
 }
 
-.navBottomBackHintContainer {
+.navBottomHintContainer {
   position: relative;
   --hint-breadth: 11px;
 }
 
-.navBottomBackHint {
+.navBottomHint {
   bottom: calc(-1 * var(--hint-breadth));
   position: absolute;
-  right: 0;
   width: 33px;
   top: calc(-1 * var(--hint-breadth));
   transform: scale(0.65, 0.65);
+}
+
+.navBottomBackHint {
   transform-origin: right;
+  right: 0;
+}
+
+.navBottomShortcutHint {
+  transform-origin: left;
+  left: 0;
 }

--- a/modules/ui/src/components/Nav/Nav.Bottom.css
+++ b/modules/ui/src/components/Nav/Nav.Bottom.css
@@ -25,6 +25,17 @@
   transform: translate3d(0, 40px, 0) scale(1.5, 1.5);
 }
 
+.navBottomDuringEntering.navBottomSame {
+  transform: translate3d(100px, 0, 0);
+}
+
+.navBottomSame {
+}
+
+.navBottomDuringExiting.navBottomSame {
+  transform: translate3d(-100px, 0, 0);
+}
+
 .navBottomBackHintContainer {
   position: relative;
   --hint-breadth: 11px;

--- a/modules/ui/src/components/Nav/Nav.BottomRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BottomRow.tsx
@@ -27,6 +27,7 @@ export type NavBottomRowProps = {
   fullNav?: boolean;
   onToggle?: () => void;
   hasBackBtn?: boolean;
+  hasShortcut?: boolean;
 };
 
 type NavBottomRowState = {
@@ -39,7 +40,7 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
     depth: -1,
     dir: "same",
   });
-  const { nav, actions, onToggle, fullNav, hasBackBtn } = props;
+  const { nav, actions, onToggle, fullNav, hasBackBtn, hasShortcut } = props;
   const { crumbs, key, me } =
     nav ||
     (({
@@ -109,7 +110,14 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
                       key={btn.id}
                       step={btn}
                       actions={actions}
-                      type={hasBackBtn && n === 0 ? "back" : "normal"}
+                      fullNav={fullNav}
+                      type={
+                        hasBackBtn && n === 0
+                          ? "back"
+                          : n === showLinks.length - 1 && hasShortcut
+                          ? "sibling"
+                          : "normal"
+                      }
                     />
                     <div
                       className={classNames(

--- a/modules/ui/src/components/Nav/Nav.BottomRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BottomRow.tsx
@@ -125,7 +125,9 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
                           >
                             <Arrow layout="eastwest" head="east" />
                           </div>
-                        ) : null)}
+                        ) : (
+                          <Arrow layout="northwest" />
+                        ))}
                     </div>
                   </Fragment>
                 ))}

--- a/modules/ui/src/components/Nav/Nav.BottomRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BottomRow.tsx
@@ -57,7 +57,7 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
         depth: count,
         dir: count > depth ? "down" : count < depth ? "up" : "same",
       }),
-    [count]
+    [crumbs]
   );
   return (
     <TransitionGroup
@@ -131,4 +131,5 @@ const whatsMyClass = (status: TransitionStatus, pos: Pos) =>
     [navBottomCss.navBottomDuringExiting]: status === "exiting",
     [navBottomCss.navBottomFurther]: pos === "further",
     [navBottomCss.navBottomNearer]: pos === "nearer",
+    [navBottomCss.navBottomSame]: pos === "same",
   });

--- a/modules/ui/src/components/Nav/Nav.BottomRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BottomRow.tsx
@@ -11,6 +11,7 @@ import Transition, {
   TransitionStatus,
 } from "react-transition-group/Transition";
 import { AlgolNav, AppActions } from "../../../../types";
+import { findShortcut } from "../../../../common/nav/findShortcut";
 import navCss from "./Nav.cssProxy";
 import navBottomCss from "./Nav.Bottom.cssProxy";
 import { NavButton } from "./Nav.Button";
@@ -46,15 +47,7 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
       key: Math.random(),
     } as unknown) as AlgolNav);
   const { links } = me;
-  const shortCut = useMemo(
-    () =>
-      links.length &&
-      crumbs.length &&
-      crumbs[crumbs.length - 1].links.find(
-        l => l.id === links[links.length - 1].id
-      ),
-    [links, crumbs]
-  );
+  const shortCut = useMemo(() => findShortcut(nav), [nav]);
   const showLinks = useMemo(
     () => (crumbs.length ? crumbs.slice(-1) : []).concat(links),
     [links, crumbs]

--- a/modules/ui/src/components/Nav/Nav.BottomRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BottomRow.tsx
@@ -16,6 +16,7 @@ import navCss from "./Nav.cssProxy";
 import navBottomCss from "./Nav.Bottom.cssProxy";
 import { NavButton } from "./Nav.Button";
 import { Arrow } from "../Arrow";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 type Dir = "up" | "down" | "same";
 type Pos = "nearer" | "further" | "same";
@@ -78,7 +79,9 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
             <div className={whatsMyClass(status, pos)}>
               <div className={classNames(navCss.navRow, navCss.navAlways)}>
                 <div className={navCss.navSideButtonContainer}>
-                  {hasBackBtn && fullNav && <Arrow layout="northeast" />}
+                  {hasBackBtn && fullNav && (
+                    <Arrow layout="northeast" dashed={DASHED_SHORTCUTS} />
+                  )}
                 </div>
                 <div
                   className={classNames(
@@ -88,7 +91,7 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
                 >
                   {hasBackBtn &&
                     (fullNav ? (
-                      <Arrow layout="eastwest" />
+                      <Arrow layout="eastwest" dashed={DASHED_SHORTCUTS} />
                     ) : (
                       <div
                         className={classNames(
@@ -126,7 +129,7 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
                             <Arrow layout="eastwest" head="east" />
                           </div>
                         ) : (
-                          <Arrow layout="northwest" />
+                          <Arrow layout="northwest" dashed={DASHED_SHORTCUTS} />
                         ))}
                     </div>
                   </Fragment>

--- a/modules/ui/src/components/Nav/Nav.BottomRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.BottomRow.tsx
@@ -46,6 +46,15 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
       key: Math.random(),
     } as unknown) as AlgolNav);
   const { links } = me;
+  const shortCut = useMemo(
+    () =>
+      links.length &&
+      crumbs.length &&
+      crumbs[crumbs.length - 1].links.find(
+        l => l.id === links[links.length - 1].id
+      ),
+    [links, crumbs]
+  );
   const showLinks = useMemo(
     () => (crumbs.length ? crumbs.slice(-1) : []).concat(links),
     [links, crumbs]
@@ -81,14 +90,19 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
                 <div
                   className={classNames(
                     navCss.navFiller,
-                    navBottomCss.navBottomBackHintContainer
+                    navBottomCss.navBottomHintContainer
                   )}
                 >
                   {hasBackBtn &&
                     (fullNav ? (
                       <Arrow layout="eastwest" />
                     ) : (
-                      <div className={navBottomCss.navBottomBackHint}>
+                      <div
+                        className={classNames(
+                          navBottomCss.navBottomHint,
+                          navBottomCss.navBottomBackHint
+                        )}
+                      >
                         <Arrow layout="northeast" head="north" />
                       </div>
                     ))}
@@ -101,7 +115,25 @@ export const NavBottomRow: FunctionComponent<NavBottomRowProps> = props => {
                       actions={actions}
                       type={hasBackBtn && n === 0 ? "back" : "normal"}
                     />
-                    <div className={navCss.navFiller}></div>
+                    <div
+                      className={classNames(
+                        navCss.navFiller,
+                        navBottomCss.navBottomHintContainer
+                      )}
+                    >
+                      {shortCut &&
+                        n === showLinks.length - 1 &&
+                        (!fullNav ? (
+                          <div
+                            className={classNames(
+                              navBottomCss.navBottomHint,
+                              navBottomCss.navBottomShortcutHint
+                            )}
+                          >
+                            <Arrow layout="eastwest" head="east" />
+                          </div>
+                        ) : null)}
+                    </div>
                   </Fragment>
                 ))}
                 <div className={navCss.navSideButtonContainer} />

--- a/modules/ui/src/components/Nav/Nav.Button.tsx
+++ b/modules/ui/src/components/Nav/Nav.Button.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from "react";
 import css from "./Nav.cssProxy";
 import { AlgolNavStep, AppActions } from "../../../../types";
 import { useNavHandler } from "./Nav.useNavHandler";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 type NavButtonProps = {
   actions: AppActions;
@@ -10,13 +11,22 @@ type NavButtonProps = {
   active?: boolean;
   mute?: boolean;
   highlight?: boolean;
+  fullNav?: boolean;
   type?: "back" | "sibling" | "normal";
 };
 
 const noop = () => {};
 
 export const NavButton: FunctionComponent<NavButtonProps> = props => {
-  const { actions, step, active, mute, highlight, type = "normal" } = props;
+  const {
+    actions,
+    step,
+    active,
+    mute,
+    highlight,
+    type = "normal",
+    fullNav,
+  } = props;
   const { title, shortTitle, desc, url } = step;
   const handleClick = useNavHandler({ actions, step });
   return (
@@ -30,7 +40,14 @@ export const NavButton: FunctionComponent<NavButtonProps> = props => {
     >
       <a
         href={url}
-        className={classNames(css.navButtonInner, mute && css.navMute)}
+        className={classNames(
+          css.navButtonInner,
+          mute && css.navMute,
+          type !== "normal" &&
+            fullNav &&
+            DASHED_SHORTCUTS &&
+            css.navButtonShortcut
+        )}
         title={desc}
         onClick={mute ? noop : handleClick}
       >

--- a/modules/ui/src/components/Nav/Nav.Crumbs.tsx
+++ b/modules/ui/src/components/Nav/Nav.Crumbs.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, Fragment } from "react";
-import { AppActions, AlgolNav } from "../../../../types";
+import { AppActions, AlgolNav, AlgolNavStep } from "../../../../types";
 import { NavStepRow } from "./Nav.StepRow";
 import NavBetweenRow from "./Nav.BetweenRow";
 
@@ -7,12 +7,11 @@ type NavCrumbsProps = {
   nav: AlgolNav;
   actions: AppActions;
   mute?: boolean;
-  hasBackBtn?: boolean;
-  hasShortcut?: boolean;
+  shortcut?: AlgolNavStep | null;
 };
 
 export const NavCrumbs: FunctionComponent<NavCrumbsProps> = props => {
-  const { nav, actions, mute, hasBackBtn, hasShortcut } = props;
+  const { nav, actions, mute, shortcut } = props;
   const { me, crumbs } = nav;
   return (
     <Fragment>
@@ -21,14 +20,15 @@ export const NavCrumbs: FunctionComponent<NavCrumbsProps> = props => {
           <NavStepRow
             actions={actions}
             step={crumb}
-            back={hasBackBtn && i === crumbs.length - 1 ? "this" : "none"}
-            shortcut={hasShortcut && i === crumbs.length - 1 ? "this" : "none"}
+            hasBackBtn
+            shortcut={shortcut}
             skipLink={i === crumbs.length - 1 ? me.title : crumbs[i + 1].title}
+            position={i === crumbs.length - 1 ? "prior" : "other"}
             mute={mute}
           />
           <NavBetweenRow
-            hasBack={hasBackBtn && i === crumbs.length - 1}
-            hasShort={hasShortcut && i === crumbs.length - 1}
+            hasBack={i === crumbs.length - 1}
+            hasShort={!!shortcut && i === crumbs.length - 1}
           />
         </Fragment>
       ))}

--- a/modules/ui/src/components/Nav/Nav.Crumbs.tsx
+++ b/modules/ui/src/components/Nav/Nav.Crumbs.tsx
@@ -8,10 +8,11 @@ type NavCrumbsProps = {
   actions: AppActions;
   mute?: boolean;
   hasBackBtn?: boolean;
+  hasShortcut?: boolean;
 };
 
 export const NavCrumbs: FunctionComponent<NavCrumbsProps> = props => {
-  const { nav, actions, mute, hasBackBtn } = props;
+  const { nav, actions, mute, hasBackBtn, hasShortcut } = props;
   const { me, crumbs } = nav;
   return (
     <Fragment>
@@ -21,10 +22,14 @@ export const NavCrumbs: FunctionComponent<NavCrumbsProps> = props => {
             actions={actions}
             step={crumb}
             back={hasBackBtn && i === crumbs.length - 1 ? "this" : "none"}
+            shortcut={hasShortcut && i === crumbs.length - 1 ? "this" : "none"}
             skipLink={i === crumbs.length - 1 ? me.title : crumbs[i + 1].title}
             mute={mute}
           />
-          <NavBetweenRow hasBack={hasBackBtn && i === crumbs.length - 1} />
+          <NavBetweenRow
+            hasBack={hasBackBtn && i === crumbs.length - 1}
+            hasShort={hasShortcut && i === crumbs.length - 1}
+          />
         </Fragment>
       ))}
     </Fragment>

--- a/modules/ui/src/components/Nav/Nav.HomeButton.css
+++ b/modules/ui/src/components/Nav/Nav.HomeButton.css
@@ -1,0 +1,11 @@
+.navHomeBtnContainer {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  height: 21px;
+  z-index: 5; /* to be above toprow */
+}
+
+.navHomeBtnContainer > * {
+  height: 21px;
+}

--- a/modules/ui/src/components/Nav/Nav.HomeButton.tsx
+++ b/modules/ui/src/components/Nav/Nav.HomeButton.tsx
@@ -1,0 +1,33 @@
+import classNames from "classnames";
+import React from "react";
+import { AlgolNavStep, AppActions } from "../../../../types";
+import { NavButton } from "./Nav.Button";
+import navCss from "./Nav.cssProxy";
+import homeCss from "./Nav.HomeButton.cssProxy";
+
+type NavHomeButtonProps = {
+  crumbs: AlgolNavStep[];
+  fullNav?: boolean;
+  actions: AppActions;
+};
+
+export const NavHomeButton = (props: NavHomeButtonProps) => {
+  const { actions, crumbs, fullNav } = props;
+  return (
+    <div
+      className={classNames(
+        homeCss.navHomeBtnContainer,
+        navCss.navSideButtonContainer
+      )}
+    >
+      {crumbs.length > 0 && (
+        <NavButton
+          type="back"
+          fullNav={fullNav}
+          step={{ ...crumbs[0], title: "H" }}
+          actions={actions}
+        />
+      )}
+    </div>
+  );
+};

--- a/modules/ui/src/components/Nav/Nav.StepRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.StepRow.tsx
@@ -10,6 +10,7 @@ import { NavButton } from "./Nav.Button";
 
 type NavStepRowProps = {
   back: "pipe" | "this" | "none";
+  shortcut: "pipe" | "this" | "none";
   step: AlgolNavStep;
   current?: boolean;
   mute?: boolean;
@@ -18,7 +19,7 @@ type NavStepRowProps = {
 };
 
 export const NavStepRow: FunctionComponent<NavStepRowProps> = props => {
-  const { back, step, current, skipLink, actions, mute } = props;
+  const { back, step, current, skipLink, actions, mute, shortcut } = props;
   return (
     <div className={navCss.navRow}>
       <div className={classNames(navCss.navFiller, navCss.navFlexLeft)}>
@@ -41,21 +42,42 @@ export const NavStepRow: FunctionComponent<NavStepRowProps> = props => {
           mute={mute}
         />
       </div>
-      <div className={classNames(navCss.navFiller, navStepCss.navStepLinkBox)}>
-        <div className={navCss.navFiller} />
-        {!current &&
-          step.links
-            .filter(l => l.title != skipLink)
-            .map(l => (
-              <Fragment key={l.title}>
-                <div className={navStepCss.navStepLinkEntry}>
-                  <Arrow head="east" layout="eastwest" />
-                  <NavButton step={l} actions={actions} mute={mute} />
-                </div>
-                <div className={navCss.navFiller} />
-              </Fragment>
-            ))}
-      </div>
+      {shortcut === "pipe" ? (
+        <div className={classNames(navCss.navFiller, navCss.navFlexRight)}>
+          <div className={navCss.navSideButtonContainer}>
+            <Arrow layout="northsouth" />
+          </div>
+        </div>
+      ) : (
+        <div
+          className={classNames(navCss.navFiller, navStepCss.navStepLinkBox)}
+        >
+          <div className={navCss.navFiller} />
+          {!current &&
+            step.links
+              .filter(l => l.title != skipLink)
+              .map(l => (
+                <Fragment key={l.title}>
+                  <div className={navStepCss.navStepLinkEntry}>
+                    <Arrow head="east" layout="eastwest" />
+                    <NavButton step={l} actions={actions} mute={mute} />
+                  </div>
+                  <div
+                    className={classNames(
+                      navCss.navFiller,
+                      shortcut === "this" && navCss.navFlexRight
+                    )}
+                  >
+                    {shortcut === "this" && (
+                      <div className={navCss.navSideButtonContainer}>
+                        <Arrow layout="northsouth" head="north" />
+                      </div>
+                    )}
+                  </div>
+                </Fragment>
+              ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/modules/ui/src/components/Nav/Nav.StepRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.StepRow.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import React, { FunctionComponent, Fragment } from "react";
 import { AlgolNavStep, AppActions } from "../../../../types";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 import navCss from "./Nav.cssProxy";
 import navStepCss from "./Nav.Step.cssProxy";
@@ -25,12 +26,15 @@ export const NavStepRow: FunctionComponent<NavStepRowProps> = props => {
       <div className={classNames(navCss.navFiller, navCss.navFlexLeft)}>
         <div className={navCss.navSideButtonContainer}>
           {back !== "none" && (
-            <Arrow layout={back === "this" ? "southeast" : "northsouth"} />
+            <Arrow
+              layout={back === "this" ? "southeast" : "northsouth"}
+              dashed={DASHED_SHORTCUTS}
+            />
           )}
         </div>
         {back === "this" && (
           <div className={navCss.navFiller}>
-            <Arrow layout="eastwest" head="east" />
+            <Arrow layout="eastwest" head="east" dashed={DASHED_SHORTCUTS} />
           </div>
         )}
       </div>
@@ -45,7 +49,7 @@ export const NavStepRow: FunctionComponent<NavStepRowProps> = props => {
       {shortcut === "pipe" ? (
         <div className={classNames(navCss.navFiller, navCss.navFlexRight)}>
           <div className={navCss.navSideButtonContainer}>
-            <Arrow layout="northsouth" />
+            <Arrow layout="northsouth" dashed />
           </div>
         </div>
       ) : (
@@ -70,7 +74,11 @@ export const NavStepRow: FunctionComponent<NavStepRowProps> = props => {
                   >
                     {shortcut === "this" && (
                       <div className={navCss.navSideButtonContainer}>
-                        <Arrow layout="northsouth" head="north" />
+                        <Arrow
+                          layout="northsouth"
+                          head="north"
+                          dashed={DASHED_SHORTCUTS}
+                        />
                       </div>
                     )}
                   </div>

--- a/modules/ui/src/components/Nav/Nav.StepRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.StepRow.tsx
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import React, { FunctionComponent, Fragment } from "react";
 import { AlgolNavStep, AppActions } from "../../../../types";
-import { DASHED_SHORTCUTS } from "./Nav.constants";
+import { DASHED_SHORTCUTS, SHORTCUT_STRATEGY } from "./Nav.constants";
 
 import navCss from "./Nav.cssProxy";
 import navStepCss from "./Nav.Step.cssProxy";
@@ -10,82 +10,138 @@ import { Arrow } from "../Arrow";
 import { NavButton } from "./Nav.Button";
 
 type NavStepRowProps = {
-  back: "pipe" | "this" | "none";
-  shortcut: "pipe" | "this" | "none";
+  hasBackBtn?: boolean;
+  shortcut?: AlgolNavStep | null;
   step: AlgolNavStep;
-  current?: boolean;
   mute?: boolean;
   skipLink?: string;
+  position: "current" | "prior" | "other";
   actions: AppActions;
 };
 
 export const NavStepRow: FunctionComponent<NavStepRowProps> = props => {
-  const { back, step, current, skipLink, actions, mute, shortcut } = props;
+  const { step, actions, mute, position } = props;
   return (
     <div className={navCss.navRow}>
-      <div className={classNames(navCss.navFiller, navCss.navFlexLeft)}>
-        <div className={navCss.navSideButtonContainer}>
-          {back !== "none" && (
-            <Arrow
-              layout={back === "this" ? "southeast" : "northsouth"}
-              dashed={DASHED_SHORTCUTS}
-            />
-          )}
-        </div>
-        {back === "this" && (
-          <div className={navCss.navFiller}>
-            <Arrow layout="eastwest" head="east" dashed={DASHED_SHORTCUTS} />
-          </div>
-        )}
-      </div>
+      <LeftSide {...props} />
       <div className={navCss.navRowStepContainer}>
         <NavStep
           step={step}
-          isCurrent={current}
+          isCurrent={position === "current"}
           actions={actions}
           mute={mute}
         />
       </div>
-      {shortcut === "pipe" ? (
+      <RightSide {...props} />
+    </div>
+  );
+};
+
+const LeftSide = ({ hasBackBtn, position }: NavStepRowProps) => (
+  <div className={classNames(navCss.navFiller, navCss.navFlexLeft)}>
+    <div className={navCss.navSideButtonContainer}>
+      {hasBackBtn && position !== "other" && (
+        <Arrow
+          layout={position === "prior" ? "southeast" : "northsouth"}
+          dashed={DASHED_SHORTCUTS}
+        />
+      )}
+    </div>
+    {hasBackBtn && position === "prior" && (
+      <div className={navCss.navFiller}>
+        <Arrow layout="eastwest" head="east" dashed={DASHED_SHORTCUTS} />
+      </div>
+    )}
+  </div>
+);
+
+const RightSide = ({
+  shortcut,
+  position,
+  skipLink,
+  actions,
+  mute,
+  step,
+}: NavStepRowProps) => {
+  if (shortcut && position === "current" && SHORTCUT_STRATEGY === "top") {
+    return (
+      <div className={classNames(navCss.navFiller, navCss.navFlexRight)}>
+        <div className={navCss.navSideButtonContainer}>
+          <Arrow layout="northsouth" dashed />
+        </div>
+      </div>
+    );
+  }
+  if (shortcut && position === "prior" && SHORTCUT_STRATEGY === "middle") {
+    return (
+      <div className={classNames(navCss.navFiller, navCss.navFlexRight)}>
+        <div className={navCss.navFiller}>
+          <Arrow layout="eastwest" />
+        </div>
+        <div className={navCss.navSideButtonContainer}>
+          <Arrow layout="southwest" />
+        </div>
+      </div>
+    );
+  }
+  if (shortcut && position === "current" && SHORTCUT_STRATEGY === "middle") {
+    return (
+      <div className={classNames(navCss.navFiller, navStepCss.navStepLinkBox)}>
         <div className={classNames(navCss.navFiller, navCss.navFlexRight)}>
           <div className={navCss.navSideButtonContainer}>
-            <Arrow layout="northsouth" dashed />
+            <Arrow layout="northsouth" head="south" />
           </div>
         </div>
-      ) : (
         <div
-          className={classNames(navCss.navFiller, navStepCss.navStepLinkBox)}
+          className={classNames(
+            navStepCss.navStepLinkEntry,
+            navCss.navFlexRight
+          )}
         >
-          <div className={navCss.navFiller} />
-          {!current &&
-            step.links
-              .filter(l => l.title != skipLink)
-              .map(l => (
-                <Fragment key={l.title}>
-                  <div className={navStepCss.navStepLinkEntry}>
-                    <Arrow head="east" layout="eastwest" />
-                    <NavButton step={l} actions={actions} mute={mute} />
-                  </div>
-                  <div
-                    className={classNames(
-                      navCss.navFiller,
-                      shortcut === "this" && navCss.navFlexRight
-                    )}
-                  >
-                    {shortcut === "this" && (
-                      <div className={navCss.navSideButtonContainer}>
-                        <Arrow
-                          layout="northsouth"
-                          head="north"
-                          dashed={DASHED_SHORTCUTS}
-                        />
-                      </div>
-                    )}
-                  </div>
-                </Fragment>
-              ))}
+          <div className="arrowContainer" />
+          <NavButton step={shortcut} actions={actions} mute={mute} />
         </div>
-      )}
+        <div className={classNames(navCss.navFiller, navCss.navFlexRight)}>
+          <div className={navCss.navSideButtonContainer}>
+            <Arrow layout="northsouth" head="north" dashed={DASHED_SHORTCUTS} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={classNames(navCss.navFiller, navStepCss.navStepLinkBox)}>
+      <div className={navCss.navFiller} />
+      {position !== "current" &&
+        step.links
+          .filter(l => l.title != skipLink)
+          .map(l => (
+            <Fragment key={l.title}>
+              <div className={navStepCss.navStepLinkEntry}>
+                <Arrow head="east" layout="eastwest" />
+                <NavButton step={l} actions={actions} mute={mute} />
+              </div>
+              <div
+                className={classNames(
+                  navCss.navFiller,
+                  shortcut && position === "prior" && navCss.navFlexRight
+                )}
+              >
+                {shortcut &&
+                  position === "prior" &&
+                  SHORTCUT_STRATEGY === "top" && (
+                    <div className={navCss.navSideButtonContainer}>
+                      <Arrow
+                        layout="northsouth"
+                        head="north"
+                        dashed={DASHED_SHORTCUTS}
+                      />
+                    </div>
+                  )}
+              </div>
+            </Fragment>
+          ))}
     </div>
   );
 };

--- a/modules/ui/src/components/Nav/Nav.ToggleButton.tsx
+++ b/modules/ui/src/components/Nav/Nav.ToggleButton.tsx
@@ -1,0 +1,34 @@
+import classNames from "classnames";
+import React from "react";
+import { NavButton } from "./Nav.Button";
+import { AppActions } from "../../../../types";
+import css from "./Nav.cssProxy";
+
+type NavToggleButtonProps = {
+  fullNav?: boolean;
+  actions: AppActions & { setFullNav: (to: boolean) => void };
+};
+
+export const NavToggleButton = (props: NavToggleButtonProps) => {
+  const { actions, fullNav } = props;
+  return (
+    <div
+      className={classNames(
+        css.navCompassBtnContainer,
+        css.navSideButtonContainer
+      )}
+    >
+      <NavButton
+        actions={actions}
+        active={fullNav}
+        step={{
+          id: "toggleNav",
+          desc: fullNav ? "Hide full nav" : "Show full nav",
+          title: "N",
+          onClick: () => actions.setFullNav(!fullNav),
+          links: [],
+        }}
+      />
+    </div>
+  );
+};

--- a/modules/ui/src/components/Nav/Nav.TopRow.tsx
+++ b/modules/ui/src/components/Nav/Nav.TopRow.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from "react";
 import navCss from "./Nav.cssProxy";
 import hintCss from "./Nav.Hint.cssProxy";
 import { Arrow } from "../Arrow";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 type NavTopRowProps = {
   fullNav?: boolean;
@@ -21,10 +22,10 @@ export const NavTopRow: FunctionComponent<NavTopRowProps> = props => {
         )}
       />
       <div className={navCss.navFiller}>
-        <Arrow layout="eastwest" />
+        <Arrow layout="eastwest" dashed={DASHED_SHORTCUTS} />
       </div>
       <div className={navCss.navSideButtonContainer}>
-        <Arrow layout="southwest" />
+        <Arrow layout="southwest" dashed={DASHED_SHORTCUTS} />
       </div>
       <div className={navCss.navFiller}></div>
       <div className={navCss.navSideButtonContainer} />

--- a/modules/ui/src/components/Nav/Nav.constants.ts
+++ b/modules/ui/src/components/Nav/Nav.constants.ts
@@ -1,1 +1,2 @@
 export const DASHED_SHORTCUTS = true;
+export const SHORTCUT_STRATEGY: "top" | "middle" = "middle";

--- a/modules/ui/src/components/Nav/Nav.constants.ts
+++ b/modules/ui/src/components/Nav/Nav.constants.ts
@@ -1,2 +1,3 @@
 export const DASHED_SHORTCUTS = true;
 export const SHORTCUT_STRATEGY: "top" | "middle" = "middle";
+export const BACK_BUTTON = true;

--- a/modules/ui/src/components/Nav/Nav.constants.ts
+++ b/modules/ui/src/components/Nav/Nav.constants.ts
@@ -1,0 +1,1 @@
+export const DASHED_SHORTCUTS = true;

--- a/modules/ui/src/components/Nav/Nav.css
+++ b/modules/ui/src/components/Nav/Nav.css
@@ -159,14 +159,6 @@
   height: 21px;
 }
 
-.navHomeBtnContainer {
-  position: absolute;
-  top: 5px;
-  left: 5px;
-  height: 21px;
-  z-index: 5; /* to be above toprow */
-}
-
 .navMapButtonContainer {
   position: absolute;
   bottom: 5px;
@@ -179,7 +171,6 @@
   left: 5px;
 }
 
-.navHomeBtnContainer > .navButton,
 .navCompassBtnContainer > .navButton,
 .navBackBtnContainer > .navButton {
   height: 21px;

--- a/modules/ui/src/components/Nav/Nav.css
+++ b/modules/ui/src/components/Nav/Nav.css
@@ -122,6 +122,10 @@
   display: block;
 }
 
+.navButtonShortcut {
+  border-style: dashed;
+}
+
 .navSideButtonContainer,
 .navSideButtonContainer .navButton {
   width: 35px;

--- a/modules/ui/src/components/Nav/Nav.css
+++ b/modules/ui/src/components/Nav/Nav.css
@@ -101,6 +101,12 @@
   align-items: stretch;
 }
 
+.navFlexRight {
+  justify-content: flex-end;
+  display: flex;
+  align-items: stretch;
+}
+
 .navButtonInner {
   pointer-events: all;
   padding: 0 3px;

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -16,6 +16,7 @@ import { NavTopRow } from "./Nav.TopRow";
 import { NavCrumbs } from "./Nav.Crumbs";
 import { NavButton } from "./Nav.Button";
 import { findShortcut } from "../../../../common/nav/findShortcut";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 export type NavProps = {
   nav?: AlgolNav;
@@ -96,7 +97,9 @@ export const Nav: FunctionComponent<NavProps> = props => {
         </div>
         <NavTopRow fullNav={fullNav && crumbs.length > 0} />
         <div className={classNames(css.navRow, css.navFiller)}>
-          {hasCrumbs && <Arrow layout="northsouth" head="south" />}
+          {hasCrumbs && (
+            <Arrow layout="northsouth" head="south" dashed={DASHED_SHORTCUTS} />
+          )}
         </div>
         <div>
           <NavCrumbs

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -1,11 +1,5 @@
 import classNames from "classnames";
-import React, {
-  FunctionComponent,
-  useMemo,
-  useState,
-  useEffect,
-  Fragment,
-} from "react";
+import React, { FunctionComponent, useMemo, useEffect, Fragment } from "react";
 import { AlgolNav, AppActions } from "../../../../types";
 import css from "./Nav.cssProxy";
 import { NavBottomRow } from "./Nav.BottomRow";
@@ -18,6 +12,7 @@ import { findShortcut } from "../../../../common/nav/findShortcut";
 import { DASHED_SHORTCUTS } from "./Nav.constants";
 import { NavHomeButton } from "./Nav.HomeButton";
 import { NavToggleButton } from "./Nav.ToggleButton";
+import { useNavState } from "./Nav.useNavSetup";
 
 export type NavProps = {
   nav?: AlgolNav;
@@ -29,22 +24,8 @@ const BACK_BUTTON = true;
 const prefetched: Record<string, boolean> = {};
 
 export const Nav: FunctionComponent<NavProps> = props => {
-  const [fullNav, _setFullNav] = useState(false);
-  const [neverNav, _setNeverNav] = useState(true);
-  const setFullNav = (bool: boolean) => {
-    if (bool && neverNav) {
-      _setNeverNav(false);
-    }
-    _setFullNav(bool);
-  };
   const { nav, actions: _actions } = props;
-  const actions = useMemo(
-    () => ({
-      ..._actions,
-      setFullNav,
-    }),
-    [_actions, setFullNav, neverNav]
-  );
+  const { actions, fullNav, neverNav } = useNavState(_actions);
   if (!nav) return <div></div>;
   const { crumbs, me } = nav;
   const hasCrumbs = Boolean(nav && crumbs.length > 0);
@@ -52,7 +33,7 @@ export const Nav: FunctionComponent<NavProps> = props => {
   const shortcut = useMemo(() => findShortcut(nav), [nav]);
 
   useEffect(() => {
-    setFullNav(false);
+    actions.setFullNav(false);
     if (nav) {
       const allSteps = nav.crumbs.concat(nav.me).flatMap(s => [s, ...s.links]);
       if (nav.me.url) {

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -14,10 +14,10 @@ import { NavStepRow } from "./Nav.StepRow";
 import { Arrow } from "../Arrow";
 import { NavTopRow } from "./Nav.TopRow";
 import { NavCrumbs } from "./Nav.Crumbs";
-import { NavButton } from "./Nav.Button";
 import { findShortcut } from "../../../../common/nav/findShortcut";
 import { DASHED_SHORTCUTS } from "./Nav.constants";
 import { NavHomeButton } from "./Nav.HomeButton";
+import { NavToggleButton } from "./Nav.ToggleButton";
 
 export type NavProps = {
   nav?: AlgolNav;
@@ -37,7 +37,14 @@ export const Nav: FunctionComponent<NavProps> = props => {
     }
     _setFullNav(bool);
   };
-  const { nav, actions } = props;
+  const { nav, actions: _actions } = props;
+  const actions = useMemo(
+    () => ({
+      ..._actions,
+      setFullNav,
+    }),
+    [_actions, setFullNav, neverNav]
+  );
   if (!nav) return <div></div>;
   const { crumbs, me } = nav;
   const hasCrumbs = Boolean(nav && crumbs.length > 0);
@@ -59,22 +66,6 @@ export const Nav: FunctionComponent<NavProps> = props => {
       }
     }
   }, [nav]);
-  const mapBtn = useMemo(
-    () => (
-      <NavButton
-        actions={actions}
-        active={fullNav}
-        step={{
-          id: "toggleNav",
-          desc: fullNav ? "Hide full nav" : "Show full nav",
-          title: "N",
-          onClick: () => setFullNav(!fullNav),
-          links: [],
-        }}
-      />
-    ),
-    [fullNav]
-  );
   return (
     <Fragment>
       <div className={css.navShadeBottom}></div>
@@ -120,14 +111,7 @@ export const Nav: FunctionComponent<NavProps> = props => {
             fullNav={fullNav}
             hasShortcut={!!shortcut}
           />
-          <div
-            className={classNames(
-              css.navCompassBtnContainer,
-              css.navSideButtonContainer
-            )}
-          >
-            {mapBtn}
-          </div>
+          <NavToggleButton fullNav={fullNav} actions={actions} />
         </div>
       </div>
     </Fragment>

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -92,7 +92,12 @@ export const Nav: FunctionComponent<NavProps> = props => {
           )}
         >
           {crumbs.length > 0 && (
-            <NavButton step={{ ...crumbs[0], title: "H" }} actions={actions} />
+            <NavButton
+              type="back"
+              fullNav={fullNav}
+              step={{ ...crumbs[0], title: "H" }}
+              actions={actions}
+            />
           )}
         </div>
         <NavTopRow fullNav={fullNav && crumbs.length > 0} />

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -127,6 +127,7 @@ export const Nav: FunctionComponent<NavProps> = props => {
             actions={actions}
             hasBackBtn={hasUpBtn}
             fullNav={fullNav}
+            hasShortcut={hasShortcut}
           />
           <div
             className={classNames(

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -104,10 +104,12 @@ export const Nav: FunctionComponent<NavProps> = props => {
             nav={nav}
             mute={!fullNav}
             hasBackBtn={hasUpBtn}
+            hasShortcut={hasShortcut}
           />
           <NavStepRow
             step={me}
             back={hasUpBtn ? "pipe" : "none"}
+            shortcut={hasShortcut ? "pipe" : "none"}
             current
             actions={actions}
             mute={!fullNav}

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -15,6 +15,7 @@ import { Arrow } from "../Arrow";
 import { NavTopRow } from "./Nav.TopRow";
 import { NavCrumbs } from "./Nav.Crumbs";
 import { NavButton } from "./Nav.Button";
+import { findShortcut } from "../../../../common/nav/findShortcut";
 
 export type NavProps = {
   nav?: AlgolNav;
@@ -39,6 +40,7 @@ export const Nav: FunctionComponent<NavProps> = props => {
   const { crumbs, me } = nav;
   const hasCrumbs = Boolean(nav && crumbs.length > 0);
   const hasUpBtn = BACK_BUTTON && hasCrumbs;
+  const hasShortcut = useMemo(() => Boolean(findShortcut(nav)), [nav]);
 
   useEffect(() => {
     setFullNav(false);
@@ -110,7 +112,11 @@ export const Nav: FunctionComponent<NavProps> = props => {
             actions={actions}
             mute={!fullNav}
           />
-          <NavLinkArrowRow nbrOfLinks={me.links.length} hasBackBtn={hasUpBtn} />
+          <NavLinkArrowRow
+            nbrOfLinks={me.links.length}
+            hasBackBtn={hasUpBtn}
+            hasShortcut={hasShortcut}
+          />
           <NavBottomRow
             nav={nav}
             actions={actions}

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { FunctionComponent, useMemo, useEffect, Fragment } from "react";
+import React, { FunctionComponent, useMemo, Fragment } from "react";
 import { AlgolNav, AppActions } from "../../../../types";
 import css from "./Nav.cssProxy";
 import { NavBottomRow } from "./Nav.BottomRow";
@@ -13,6 +13,7 @@ import { DASHED_SHORTCUTS } from "./Nav.constants";
 import { NavHomeButton } from "./Nav.HomeButton";
 import { NavToggleButton } from "./Nav.ToggleButton";
 import { useNavState } from "./Nav.useNavSetup";
+import { useNavPrefetch } from "./Nav.useNavPrefetch.";
 
 export type NavProps = {
   nav?: AlgolNav;
@@ -21,32 +22,16 @@ export type NavProps = {
 
 const BACK_BUTTON = true;
 
-const prefetched: Record<string, boolean> = {};
-
 export const Nav: FunctionComponent<NavProps> = props => {
   const { nav, actions: _actions } = props;
   const { actions, fullNav, neverNav } = useNavState(_actions);
+  useNavPrefetch({ actions, nav });
   if (!nav) return <div></div>;
   const { crumbs, me } = nav;
   const hasCrumbs = Boolean(nav && crumbs.length > 0);
   const hasUpBtn = BACK_BUTTON && hasCrumbs;
   const shortcut = useMemo(() => findShortcut(nav), [nav]);
 
-  useEffect(() => {
-    actions.setFullNav(false);
-    if (nav) {
-      const allSteps = nav.crumbs.concat(nav.me).flatMap(s => [s, ...s.links]);
-      if (nav.me.url) {
-        prefetched[nav.me.url] = true;
-      }
-      for (const s of allSteps) {
-        if (s.url && s !== nav.me && !prefetched[s.url]) {
-          actions.prefetch(s.url);
-          prefetched[s.url] = true;
-        }
-      }
-    }
-  }, [nav]);
   return (
     <Fragment>
       <div className={css.navShadeBottom}></div>

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -111,7 +111,12 @@ export const Nav: FunctionComponent<NavProps> = props => {
             mute={!fullNav}
           />
           <NavLinkArrowRow nbrOfLinks={me.links.length} hasBackBtn={hasUpBtn} />
-          <NavBottomRow {...props} hasBackBtn={hasUpBtn} fullNav={fullNav} />
+          <NavBottomRow
+            nav={nav}
+            actions={actions}
+            hasBackBtn={hasUpBtn}
+            fullNav={fullNav}
+          />
           <div
             className={classNames(
               css.navCompassBtnContainer,

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { FunctionComponent, useMemo, Fragment } from "react";
+import React, { Fragment } from "react";
 import { AlgolNav, AppActions } from "../../../../types";
 import css from "./Nav.cssProxy";
 import { NavBottomRow } from "./Nav.BottomRow";
@@ -8,7 +8,6 @@ import { NavStepRow } from "./Nav.StepRow";
 import { Arrow } from "../Arrow";
 import { NavTopRow } from "./Nav.TopRow";
 import { NavCrumbs } from "./Nav.Crumbs";
-import { findShortcut } from "../../../../common/nav/findShortcut";
 import { DASHED_SHORTCUTS } from "./Nav.constants";
 import { NavHomeButton } from "./Nav.HomeButton";
 import { NavToggleButton } from "./Nav.ToggleButton";
@@ -20,17 +19,19 @@ export type NavProps = {
   actions: AppActions;
 };
 
-const BACK_BUTTON = true;
-
-export const Nav: FunctionComponent<NavProps> = props => {
-  const { nav, actions: _actions } = props;
-  const { actions, fullNav, neverNav } = useNavState(_actions);
+export const Nav = (props: NavProps) => {
+  const { nav } = props;
+  const {
+    actions,
+    fullNav,
+    neverNav,
+    hasCrumbs,
+    hasUpBtn,
+    shortcut,
+  } = useNavState(props);
   useNavPrefetch({ actions, nav });
   if (!nav) return <div></div>;
   const { crumbs, me } = nav;
-  const hasCrumbs = Boolean(nav && crumbs.length > 0);
-  const hasUpBtn = BACK_BUTTON && hasCrumbs;
-  const shortcut = useMemo(() => findShortcut(nav), [nav]);
 
   return (
     <Fragment>

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -17,6 +17,7 @@ import { NavCrumbs } from "./Nav.Crumbs";
 import { NavButton } from "./Nav.Button";
 import { findShortcut } from "../../../../common/nav/findShortcut";
 import { DASHED_SHORTCUTS } from "./Nav.constants";
+import { NavHomeButton } from "./Nav.HomeButton";
 
 export type NavProps = {
   nav?: AlgolNav;
@@ -85,21 +86,7 @@ export const Nav: FunctionComponent<NavProps> = props => {
         )}
         // onClick={e => setFullNav(false)}
       >
-        <div
-          className={classNames(
-            css.navHomeBtnContainer,
-            css.navSideButtonContainer
-          )}
-        >
-          {crumbs.length > 0 && (
-            <NavButton
-              type="back"
-              fullNav={fullNav}
-              step={{ ...crumbs[0], title: "H" }}
-              actions={actions}
-            />
-          )}
-        </div>
+        <NavHomeButton fullNav={fullNav} crumbs={crumbs} actions={actions} />
         <NavTopRow fullNav={fullNav && crumbs.length > 0} />
         <div className={classNames(css.navRow, css.navFiller)}>
           {hasCrumbs && (

--- a/modules/ui/src/components/Nav/Nav.tsx
+++ b/modules/ui/src/components/Nav/Nav.tsx
@@ -41,7 +41,7 @@ export const Nav: FunctionComponent<NavProps> = props => {
   const { crumbs, me } = nav;
   const hasCrumbs = Boolean(nav && crumbs.length > 0);
   const hasUpBtn = BACK_BUTTON && hasCrumbs;
-  const hasShortcut = useMemo(() => Boolean(findShortcut(nav)), [nav]);
+  const shortcut = useMemo(() => findShortcut(nav), [nav]);
 
   useEffect(() => {
     setFullNav(false);
@@ -106,28 +106,27 @@ export const Nav: FunctionComponent<NavProps> = props => {
             actions={actions}
             nav={nav}
             mute={!fullNav}
-            hasBackBtn={hasUpBtn}
-            hasShortcut={hasShortcut}
+            shortcut={shortcut}
           />
           <NavStepRow
             step={me}
-            back={hasUpBtn ? "pipe" : "none"}
-            shortcut={hasShortcut ? "pipe" : "none"}
-            current
+            hasBackBtn={hasUpBtn}
+            shortcut={shortcut}
+            position="current"
             actions={actions}
             mute={!fullNav}
           />
           <NavLinkArrowRow
             nbrOfLinks={me.links.length}
             hasBackBtn={hasUpBtn}
-            hasShortcut={hasShortcut}
+            hasShortcut={!!shortcut}
           />
           <NavBottomRow
             nav={nav}
             actions={actions}
             hasBackBtn={hasUpBtn}
             fullNav={fullNav}
-            hasShortcut={hasShortcut}
+            hasShortcut={!!shortcut}
           />
           <div
             className={classNames(

--- a/modules/ui/src/components/Nav/Nav.useNavPrefetch..ts
+++ b/modules/ui/src/components/Nav/Nav.useNavPrefetch..ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { AlgolNav, AppActions } from "../../../../types";
+
+type UseNavPrefetchOpts = {
+  nav?: AlgolNav | undefined;
+  actions: AppActions & { setFullNav: (to: boolean) => void };
+};
+
+const prefetched: Record<string, boolean> = {};
+
+export const useNavPrefetch = (opts: UseNavPrefetchOpts) => {
+  const { actions, nav } = opts;
+  useEffect(() => {
+    actions.setFullNav(false);
+    if (nav) {
+      const allSteps = nav.crumbs.concat(nav.me).flatMap(s => [s, ...s.links]);
+      if (nav.me.url) {
+        prefetched[nav.me.url] = true;
+      }
+      for (const s of allSteps) {
+        if (s.url && s !== nav.me && !prefetched[s.url]) {
+          actions.prefetch(s.url);
+          prefetched[s.url] = true;
+        }
+      }
+    }
+  }, [nav]);
+};

--- a/modules/ui/src/components/Nav/Nav.useNavSetup.ts
+++ b/modules/ui/src/components/Nav/Nav.useNavSetup.ts
@@ -1,0 +1,22 @@
+import { useCallback, useMemo, useState } from "react";
+import { AppActions } from "../../../../types";
+
+export const useNavState = (appActions: AppActions) => {
+  const [fullNav, _setFullNav] = useState(false);
+  const [neverNav, _setNeverNav] = useState(true);
+  const setFullNav = useCallback(
+    (bool: boolean) => {
+      _setNeverNav(false);
+      _setFullNav(bool);
+    },
+    [_setNeverNav, _setFullNav]
+  );
+  const actions = useMemo(
+    () => ({
+      ...appActions,
+      setFullNav,
+    }),
+    [appActions, setFullNav]
+  );
+  return { fullNav, neverNav, actions };
+};

--- a/modules/ui/src/components/Nav/Nav.useNavSetup.ts
+++ b/modules/ui/src/components/Nav/Nav.useNavSetup.ts
@@ -1,7 +1,15 @@
 import { useCallback, useMemo, useState } from "react";
-import { AppActions } from "../../../../types";
+import { findShortcut } from "../../../../common/nav/findShortcut";
+import { AlgolNav, AppActions } from "../../../../types";
+import { BACK_BUTTON } from "./Nav.constants";
 
-export const useNavState = (appActions: AppActions) => {
+type UseNavStateOpts = {
+  actions: AppActions;
+  nav?: AlgolNav;
+};
+
+export const useNavState = (opts: UseNavStateOpts) => {
+  const { actions: appActions, nav } = opts;
   const [fullNav, _setFullNav] = useState(false);
   const [neverNav, _setNeverNav] = useState(true);
   const setFullNav = useCallback(
@@ -18,5 +26,8 @@ export const useNavState = (appActions: AppActions) => {
     }),
     [appActions, setFullNav]
   );
-  return { fullNav, neverNav, actions };
+  const hasCrumbs = Boolean(nav && nav.crumbs.length > 0);
+  const hasUpBtn = BACK_BUTTON && hasCrumbs;
+  const shortcut = useMemo(() => findShortcut(nav), [nav]);
+  return { fullNav, neverNav, actions, hasCrumbs, hasUpBtn, shortcut };
 };

--- a/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
+++ b/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
@@ -3,15 +3,16 @@ import React, { FunctionComponent } from "react";
 import navCss from "./Nav.cssProxy";
 import hintCss from "./Nav.Hint.cssProxy";
 import { Arrow } from "../Arrow";
-import { ArrowMulti } from "../Arrow/Arrow.Multi";
+import { ArrowMulti, ArrowMultiProps } from "../Arrow/Arrow.Multi";
 
 type NavLinkArrowRowProps = {
   nbrOfLinks: number;
   hasBackBtn?: boolean;
+  hasShortcut?: boolean;
 };
 
 export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props => {
-  const { nbrOfLinks, hasBackBtn } = props;
+  const { nbrOfLinks, hasBackBtn, hasShortcut } = props;
   const pieceCount = nbrOfLinks ? nbrOfLinks * 2 + (hasBackBtn ? 3 : 1) : 0;
   const middle = Math.ceil(pieceCount / 2);
   const pieces = [];
@@ -21,11 +22,9 @@ export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props =>
       pieces.push(
         <div key={i} className={navCss.navFiller}>
           {i === middle ? (
-            hasBackBtn ? (
-              <Arrow layout="northeast" />
-            ) : (
-              <ArrowMulti northwest northeast />
-            )
+            <ArrowMulti
+              {...middleArrows(nbrOfLinks, hasBackBtn, hasShortcut)}
+            />
           ) : i > 1 && i < pieceCount && !(i < middle && hasBackBtn) ? (
             <Arrow layout="eastwest" />
           ) : null}
@@ -42,16 +41,9 @@ export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props =>
               <ArrowMulti southeast eastwest head="south" />
             )
           ) : i === middle ? (
-            nbrOfLinks === 1 ? (
-              <Arrow layout="northsouth" head="south" />
-            ) : (
-              <ArrowMulti
-                head="south"
-                northsouth
-                northeast
-                northwest={!hasBackBtn}
-              />
-            )
+            <ArrowMulti
+              {...middleArrows(nbrOfLinks, hasBackBtn, hasShortcut)}
+            />
           ) : i === pieceCount - 1 ? (
             <Arrow layout="southwest" head="south" />
           ) : (
@@ -75,4 +67,20 @@ export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props =>
       <div className={navCss.navSideButtonContainer}></div>
     </div>
   );
+};
+
+const middleArrows = (
+  nbrOfLinks: number,
+  hasBackBtn?: boolean,
+  hasShortcut?: boolean
+): ArrowMultiProps => {
+  const count = nbrOfLinks + (hasBackBtn ? 1 : 0);
+  const odd = Boolean(count % 2);
+  const result: ArrowMultiProps = {
+    head: odd ? "south" : undefined,
+    northsouth: odd,
+    northeast: count > 1,
+    northwest: count > 1 && !hasBackBtn,
+  };
+  return result;
 };

--- a/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
+++ b/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
@@ -45,8 +45,12 @@ export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props =>
       </div>
       <div className={navCss.navFiller} />
       {pieces}
-      <div className={navCss.navFiller} />
-      <div className={navCss.navSideButtonContainer}></div>
+      <div className={navCss.navFiller}>
+        {hasShortcut && <Arrow layout="southeast" />}
+      </div>
+      <div className={navCss.navSideButtonContainer}>
+        {hasShortcut && <Arrow layout="northwest" />}
+      </div>
     </div>
   );
 };

--- a/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
+++ b/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
@@ -13,42 +13,22 @@ type NavLinkArrowRowProps = {
 
 export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props => {
   const { nbrOfLinks, hasBackBtn, hasShortcut } = props;
-  const pieceCount = nbrOfLinks ? nbrOfLinks * 2 + (hasBackBtn ? 3 : 1) : 0;
+  const buttonCount = nbrOfLinks + (hasBackBtn ? 1 : 0);
+  const pieceCount = buttonCount * 2 - 1;
   const middle = Math.ceil(pieceCount / 2);
   const pieces = [];
   for (let i = 1; i <= pieceCount; i++) {
+    const side = i < middle ? "left" : i > middle ? "right" : "middle";
     if (i % 2) {
-      // filler
       pieces.push(
-        <div key={i} className={navCss.navFiller}>
-          {i === middle ? (
-            <ArrowMulti
-              {...middleArrows(nbrOfLinks, hasBackBtn, hasShortcut)}
-            />
-          ) : i > 1 && i < pieceCount && !(i < middle && hasBackBtn) ? (
-            <Arrow layout="eastwest" />
-          ) : null}
+        <div key={i} className={navCss.navButton}>
+          {aboveButtonArrows(side, buttonCount, hasBackBtn, hasShortcut)}
         </div>
       );
     } else {
-      // above button
       pieces.push(
-        <div key={i} className={navCss.navButton}>
-          {i < middle ? (
-            hasBackBtn ? null : i === 2 ? (
-              <Arrow layout="southeast" head="south" />
-            ) : (
-              <ArrowMulti southeast eastwest head="south" />
-            )
-          ) : i === middle ? (
-            <ArrowMulti
-              {...middleArrows(nbrOfLinks, hasBackBtn, hasShortcut)}
-            />
-          ) : i === pieceCount - 1 ? (
-            <Arrow layout="southwest" head="south" />
-          ) : (
-            <ArrowMulti southwest eastwest head="south" />
-          )}
+        <div key={i} className={navCss.navFiller}>
+          {spaceArrows(side, buttonCount, hasBackBtn, hasShortcut)}
         </div>
       );
     }
@@ -63,24 +43,48 @@ export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props =>
       >
         {hasBackBtn && <Arrow layout="northsouth" />}
       </div>
+      <div className={navCss.navFiller} />
       {pieces}
+      <div className={navCss.navFiller} />
       <div className={navCss.navSideButtonContainer}></div>
     </div>
   );
 };
 
-const middleArrows = (
-  nbrOfLinks: number,
+const spaceArrows = (
+  side: "left" | "middle" | "right",
+  buttonCount: number,
   hasBackBtn?: boolean,
   hasShortcut?: boolean
-): ArrowMultiProps => {
-  const count = nbrOfLinks + (hasBackBtn ? 1 : 0);
-  const odd = Boolean(count % 2);
-  const result: ArrowMultiProps = {
-    head: odd ? "south" : undefined,
-    northsouth: odd,
-    northeast: count > 1,
-    northwest: count > 1 && !hasBackBtn,
-  };
-  return result;
-};
+) => (
+  <ArrowMulti
+    northwest={side === "middle" && buttonCount > 1 && !hasBackBtn}
+    northeast={side === "middle" && buttonCount > 1 && !hasShortcut}
+    eastwest={
+      (side === "left" && buttonCount > 1 && !hasBackBtn) ||
+      (side === "right" && buttonCount > 1 && !hasShortcut)
+    }
+  />
+);
+
+const aboveButtonArrows = (
+  side: "left" | "middle" | "right",
+  buttonCount: number,
+  hasBackBtn?: boolean,
+  hasShortcut?: boolean
+) => (
+  <ArrowMulti
+    head={
+      (side === "middle" && (!hasBackBtn || buttonCount > 1)) ||
+      (side === "right" && !hasShortcut) ||
+      (side === "left" && !hasBackBtn)
+        ? "south"
+        : undefined
+    }
+    northsouth={side === "middle" && (!hasBackBtn || buttonCount > 1)}
+    northeast={side === "middle" && buttonCount > 1 && !hasShortcut}
+    northwest={side === "middle" && buttonCount > 1 && !hasBackBtn}
+    southeast={side === "left" && !hasBackBtn}
+    southwest={side === "right" && !hasShortcut}
+  />
+);

--- a/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
+++ b/modules/ui/src/components/Nav/NavLinkArrowRow.tsx
@@ -4,6 +4,7 @@ import navCss from "./Nav.cssProxy";
 import hintCss from "./Nav.Hint.cssProxy";
 import { Arrow } from "../Arrow";
 import { ArrowMulti, ArrowMultiProps } from "../Arrow/Arrow.Multi";
+import { DASHED_SHORTCUTS } from "./Nav.constants";
 
 type NavLinkArrowRowProps = {
   nbrOfLinks: number;
@@ -41,15 +42,15 @@ export const NavLinkArrowRow: FunctionComponent<NavLinkArrowRowProps> = props =>
           hasBackBtn && hintCss.navHintBack
         )}
       >
-        {hasBackBtn && <Arrow layout="northsouth" />}
+        {hasBackBtn && <Arrow layout="northsouth" dashed={DASHED_SHORTCUTS} />}
       </div>
       <div className={navCss.navFiller} />
       {pieces}
       <div className={navCss.navFiller}>
-        {hasShortcut && <Arrow layout="southeast" />}
+        {hasShortcut && <Arrow layout="southeast" dashed={DASHED_SHORTCUTS} />}
       </div>
       <div className={navCss.navSideButtonContainer}>
-        {hasShortcut && <Arrow layout="northwest" />}
+        {hasShortcut && <Arrow layout="northwest" dashed={DASHED_SHORTCUTS} />}
       </div>
     </div>
   );


### PR DESCRIPTION
- [x] Make sideways navigation transition left-right
- [x] Add links between rules and info
- [x] Add links between history and playing
- [x] Make sideways links have right-pointing arrow
- [x] Make sideways link not have line from current in fullNav
- [x] Make sideways link have arrow back to target in fullNav
- [x] Try special style for shortcut links
- [x] Extract logic from main nav component into links
- [x] Split out components for navtoggle and homebutton from main nav

Fixes #364 


Shortcut from rules to info:

![image](https://user-images.githubusercontent.com/249764/94330942-302d3580-ffc9-11ea-9f89-a8fe31ad6ab8.png)

Shortcut in fullnav:

![image](https://user-images.githubusercontent.com/249764/94330953-40ddab80-ffc9-11ea-85fa-a18a404cc527.png)

Same thing between controls and history in a battle.

Also added variant where we show "sibling" next to current:

![image](https://user-images.githubusercontent.com/249764/94344419-8cbb3f80-001f-11eb-8486-5cbaa83ec972.png)
