### PR TITLE
Support holes in board definitions

### DIFF
--- a/modules/common/connections/boardConnections.test.ts
+++ b/modules/common/connections/boardConnections.test.ts
@@ -23,4 +23,9 @@ describe("common/boardConnections", () => {
     expect(res.b3["d5f2r-1"]).toBe("c1");
     expect(res.b3["d5f2r1"]).toBe("a1");
   });
+  test("wont link to holes", () => {
+    const res = boardConnections({ height: 3, width: 3, holes: ["a3"] });
+    expect(res.a3).toBeUndefined();
+    expect(res.a2[1]).toBeUndefined();
+  });
 });

--- a/modules/common/connections/boardConnections.ts
+++ b/modules/common/connections/boardConnections.ts
@@ -6,7 +6,7 @@ import { AlgolBoardAnon } from "../../types";
 Calculates the connections object
 */
 export function boardConnections(board: AlgolBoardAnon) {
-  return boardPositions(board.height, board.width).reduce(
+  return boardPositions(board).reduce(
     function(mem, pos) {
       mem[pos] = posConnections(pos, board);
       return mem;

--- a/modules/common/layers/boardLayers.ts
+++ b/modules/common/layers/boardLayers.ts
@@ -5,7 +5,7 @@ import { boardPositions, pos2coords } from "../";
 Calculates the three BOARD layers (board,light,dark) and returns them.
 */
 export function boardLayers(board: AlgolBoardAnon) {
-  return boardPositions(board.height, board.width).reduce(
+  return boardPositions(board).reduce(
     function(mem, pos) {
       var coords = pos2coords(pos);
       var colour = ["dark", "light"][(coords.x + (coords.y % 2)) % 2];

--- a/modules/common/layers/terrainLayerNames.ts
+++ b/modules/common/layers/terrainLayerNames.ts
@@ -4,7 +4,7 @@ import { AlgolBoardAnon } from "../../types";
 // TODO - pass full gameDef so that we can mix in AI too!
 export function terrainLayerNames(board: AlgolBoardAnon) {
   return Object.keys({
-    ...terrainLayers(board.height, board.width, board.terrain, 1),
-    ...terrainLayers(board.height, board.width, board.terrain, 2)
+    ...terrainLayers(board, 1),
+    ...terrainLayers(board, 2),
   });
 }

--- a/modules/common/layers/terrainLayers.test.ts
+++ b/modules/common/layers/terrainLayers.test.ts
@@ -16,19 +16,21 @@ type TerrainTest = {
   forPlayer?: 1 | 2;
 };
 
+const two = 2 as 3; // just to make TS shut up, since 3 is minimum board size
+
 const terrainTests: TerrainTest[] = [
   {
-    board: { height: 2, width: 2, terrain: { knork: ["a1", "b2"] } },
+    board: { height: two, width: two, terrain: { knork: ["a1", "b2"] } },
     expected: {
       knork: { a1: { pos: "a1", x: 1, y: 1 }, b2: { pos: "b2", x: 2, y: 2 } },
-      noknork: { a2: { pos: "a2", x: 1, y: 2 }, b1: { pos: "b1", x: 2, y: 1 } }
-    }
+      noknork: { a2: { pos: "a2", x: 1, y: 2 }, b1: { pos: "b1", x: 2, y: 1 } },
+    },
   },
   {
     board: {
-      height: 2,
-      width: 2,
-      terrain: { knork: { 1: ["a1", "b2"], 2: ["a2", "b1"] } }
+      height: two,
+      width: two,
+      terrain: { knork: { 1: ["a1", "b2"], 2: ["a2", "b1"] } },
     },
     forPlayer: 1,
     expected: {
@@ -36,25 +38,23 @@ const terrainTests: TerrainTest[] = [
         a1: { pos: "a1", x: 1, y: 1, owner: 1 },
         b2: { pos: "b2", x: 2, y: 2, owner: 1 },
         a2: { pos: "a2", x: 1, y: 2, owner: 2 },
-        b1: { pos: "b1", x: 2, y: 1, owner: 2 }
+        b1: { pos: "b1", x: 2, y: 1, owner: 2 },
       },
       myknork: {
         a1: { pos: "a1", x: 1, y: 1, owner: 1 },
-        b2: { pos: "b2", x: 2, y: 2, owner: 1 }
+        b2: { pos: "b2", x: 2, y: 2, owner: 1 },
       },
       oppknork: {
         a2: { pos: "a2", x: 1, y: 2, owner: 2 },
-        b1: { pos: "b1", x: 2, y: 1, owner: 2 }
+        b1: { pos: "b1", x: 2, y: 1, owner: 2 },
       },
-      noknork: {}
-    }
-  }
+      noknork: {},
+    },
+  },
 ];
 
 test("terrainLayers", () => {
   terrainTests.forEach(({ board, forPlayer, expected }) =>
-    expect(
-      terrainLayers(board.height, board.width, board.terrain, forPlayer)
-    ).toEqual(expected)
+    expect(terrainLayers(board, forPlayer)).toEqual(expected)
   );
 });

--- a/modules/common/layers/terrainLayers.ts
+++ b/modules/common/layers/terrainLayers.ts
@@ -1,4 +1,4 @@
-import { TerrainDefAnon, LayerCollection, Layer } from "../../types";
+import { TerrainDefAnon, LayerCollection, AlgolBoardAnon } from "../../types";
 import { processEntity, boardPositions } from "../";
 
 /*
@@ -6,45 +6,41 @@ Calculates all terrain layers and returns them.
 This should be done per player if any terrain has owner.
 */
 export function terrainLayers(
-  height: number,
-  width: number,
-  terrainDef: { [terrain: string]: TerrainDefAnon } = {},
+  board: AlgolBoardAnon,
   forplayer?: 1 | 2
 ): LayerCollection {
+  const { terrain: terrainDef = {}, height, width } = board;
   if (!Object.keys(terrainDef).length) {
     return {};
   }
-  let terrain = Object.keys(terrainDef).reduce(
-    (mem, name) => {
-      let def = terrainDef[name];
-      mem[name] = {};
-      if (Array.isArray(def)) {
-        // no ownership, we got array of entityddefs directly
-        def.forEach(function(entityDef) {
+  let terrain = Object.keys(terrainDef).reduce((mem, name) => {
+    let def = terrainDef[name];
+    mem[name] = {};
+    if (Array.isArray(def)) {
+      // no ownership, we got array of entityddefs directly
+      def.forEach(function(entityDef) {
+        processEntity(entityDef).forEach(e => {
+          mem[name][e.pos] = e;
+        });
+      });
+    } else {
+      // per-player object
+      for (let o in def) {
+        let owner = parseInt(o);
+        def[owner as 0 | 1 | 2]!.forEach(entityDef => {
           processEntity(entityDef).forEach(e => {
+            e.owner = owner;
             mem[name][e.pos] = e;
+            let prefix =
+              owner == 0 ? "neutral" : owner == forplayer ? "my" : "opp";
+            mem[prefix + name] = mem[prefix + name] || {};
+            mem[prefix + name][e.pos] = e;
           });
         });
-      } else {
-        // per-player object
-        for (let o in def) {
-          let owner = parseInt(o);
-          def[owner as 0 | 1 | 2]!.forEach(entityDef => {
-            processEntity(entityDef).forEach(e => {
-              e.owner = owner;
-              mem[name][e.pos] = e;
-              let prefix =
-                owner == 0 ? "neutral" : owner == forplayer ? "my" : "opp";
-              mem[prefix + name] = mem[prefix + name] || {};
-              mem[prefix + name][e.pos] = e;
-            });
-          });
-        }
       }
-      return mem;
-    },
-    {} as LayerCollection
-  );
+    }
+    return mem;
+  }, {} as LayerCollection);
   // add no-variants of layers and return
   return Object.keys(terrain).reduce((mem, name) => {
     if (!name.match(/^my/) && !name.match(/^opp/)) {

--- a/modules/common/layers/terrainLayers.ts
+++ b/modules/common/layers/terrainLayers.ts
@@ -9,7 +9,7 @@ export function terrainLayers(
   board: AlgolBoardAnon,
   forplayer?: 1 | 2
 ): LayerCollection {
-  const { terrain: terrainDef = {}, height, width } = board;
+  const { terrain: terrainDef = {} } = board;
   if (!Object.keys(terrainDef).length) {
     return {};
   }
@@ -47,7 +47,7 @@ export function terrainLayers(
       let t = terrain[name];
       let noname = "no" + name;
       mem[noname] = {};
-      boardPositions(height, width).forEach(pos => {
+      boardPositions(board).forEach(pos => {
         if (!t[pos]) {
           mem[noname][pos] = processEntity(pos)[0];
         }

--- a/modules/common/positions/boardHoles.ts
+++ b/modules/common/positions/boardHoles.ts
@@ -1,0 +1,10 @@
+import { coords2pos } from "../";
+import { AlgolBoardAnon } from "../../types";
+import { processEntity } from "../entities";
+
+export function boardHoles(board: AlgolBoardAnon) {
+  return (board.holes || [])
+    .flatMap(processEntity)
+    .map(coords2pos)
+    .sort();
+}

--- a/modules/common/positions/boardPositions.test.ts
+++ b/modules/common/positions/boardPositions.test.ts
@@ -1,9 +1,20 @@
 import { boardPositions } from "..";
 import { AlgolBoardAnon } from "../../types";
-
-test("boardPositions", () => {
-  const board = ({ height: 2, width: 3 } as unknown) as AlgolBoardAnon;
-  const result = boardPositions(board);
-  const expected = ["a1", "a2", "b1", "b2", "c1", "c2"];
-  expect(result).toEqual(expected);
+describe("boardPositions", () => {
+  test("normal board", () => {
+    const board = ({ height: 2, width: 3 } as unknown) as AlgolBoardAnon;
+    const result = boardPositions(board);
+    const expected = ["a1", "a2", "b1", "b2", "c1", "c2"];
+    expect(result).toEqual(expected);
+  });
+  test("board with holes", () => {
+    const board: AlgolBoardAnon = {
+      height: 3,
+      width: 3,
+      holes: [{ rect: ["a1", "b2"] }, "c3"],
+    };
+    const result = boardPositions(board);
+    const expected = ["a3", "b3", "c1", "c2"];
+    expect(result).toEqual(expected);
+  });
 });

--- a/modules/common/positions/boardPositions.test.ts
+++ b/modules/common/positions/boardPositions.test.ts
@@ -1,7 +1,9 @@
 import { boardPositions } from "..";
+import { AlgolBoardAnon } from "../../types";
 
 test("boardPositions", () => {
-  const result = boardPositions(2, 3);
+  const board = ({ height: 2, width: 3 } as unknown) as AlgolBoardAnon;
+  const result = boardPositions(board);
   const expected = ["a1", "a2", "b1", "b2", "c1", "c2"];
   expect(result).toEqual(expected);
 });

--- a/modules/common/positions/boardPositions.ts
+++ b/modules/common/positions/boardPositions.ts
@@ -1,11 +1,11 @@
 import { coords2pos } from "../";
 import { AlgolBoardAnon } from "../../types";
-import { processEntity } from "../entities";
+import { boardHoles } from "./boardHoles";
 
 export function boardPositions(board: AlgolBoardAnon) {
   const { height, width } = board;
   const ret = [];
-  const holes = (board.holes || []).flatMap(processEntity).map(coords2pos);
+  const holes = boardHoles(board);
   for (let y = 1; y <= height; y++) {
     for (let x = 1; x <= width; x++) {
       const pos = coords2pos({ x: x, y: y });

--- a/modules/common/positions/boardPositions.ts
+++ b/modules/common/positions/boardPositions.ts
@@ -1,12 +1,17 @@
 import { coords2pos } from "../";
 import { AlgolBoardAnon } from "../../types";
+import { processEntity } from "../entities";
 
 export function boardPositions(board: AlgolBoardAnon) {
   const { height, width } = board;
-  let ret = [];
+  const ret = [];
+  const holes = (board.holes || []).flatMap(processEntity).map(coords2pos);
   for (let y = 1; y <= height; y++) {
     for (let x = 1; x <= width; x++) {
-      ret.push(coords2pos({ x: x, y: y }));
+      const pos = coords2pos({ x: x, y: y });
+      if (!holes.includes(pos)) {
+        ret.push(pos);
+      }
     }
   }
   return ret.sort();

--- a/modules/common/positions/boardPositions.ts
+++ b/modules/common/positions/boardPositions.ts
@@ -1,6 +1,8 @@
 import { coords2pos } from "../";
+import { AlgolBoardAnon } from "../../types";
 
-export function boardPositions(height: number, width: number) {
+export function boardPositions(board: AlgolBoardAnon) {
+  const { height, width } = board;
   let ret = [];
   for (let y = 1; y <= height; y++) {
     for (let x = 1; x <= width; x++) {

--- a/modules/common/positions/index.ts
+++ b/modules/common/positions/index.ts
@@ -3,6 +3,7 @@ export * from "./boardPositions";
 export * from "./coords2pos";
 export * from "./offsetPos";
 export * from "./griddef2grid";
+export * from "./boardHoles";
 
 export const colname2number = "ZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVXY"
   .split("")

--- a/modules/common/positions/offsetPos.ts
+++ b/modules/common/positions/offsetPos.ts
@@ -1,5 +1,6 @@
 import { AlgolBoardAnon } from "../../types";
 import { pos2coords, coords2pos } from "../";
+import { boardHoles } from "./boardHoles";
 
 export function offsetPos(
   pos: string,
@@ -32,8 +33,13 @@ export function offsetPos(
   const coords = pos2coords(pos);
   const newx = coords.x + forwardmods[n][0] * forward + rightmods[n][0] * right;
   const newy = coords.y + forwardmods[n][1] * forward + rightmods[n][1] * right;
+  const newPos = coords2pos({ x: newx, y: newy });
   const withinbounds = board
-    ? newx > 0 && newx <= board.width && newy > 0 && newy <= board.height
+    ? newx > 0 &&
+      newx <= board.width &&
+      newy > 0 &&
+      newy <= board.height &&
+      !boardHoles(board).includes(newPos)
     : true;
-  return withinbounds && coords2pos({ x: newx, y: newy });
+  return withinbounds && newPos;
 }

--- a/modules/games/commands/helpers/analyze.ts
+++ b/modules/games/commands/helpers/analyze.ts
@@ -11,7 +11,7 @@ import {
   isAlgolEffectSetTurnVar,
   isAlgolEffectSetBattleVar,
   isAlgolEffectIncreaseTurnVar,
-  isAlgolEffectIncreaseBattleVar,
+  isAlgolEffectIncreaseBattleVar,, AlgolBoardAnon
 } from "../../../types";
 import {
   boardPositions,
@@ -42,6 +42,7 @@ export default async function analyze(def: FullDefAnon | string) {
     }),
     { maxHeight: 0, maxWidth: 0 }
   );
+  const maxBoard = { height: maxHeight, width: maxWidth } as unknown as AlgolBoardAnon
   const terrains = Array.from(
     new Set(
       Object.values(boards).flatMap(board => Object.keys(board.terrain || {}))
@@ -220,7 +221,7 @@ type ${capId}Grid = ${
     gridNames.length ? gridNames.map(t => `"${t}"`).join(" | ") : "never"
   };
 
-type ${capId}Position = ${boardPositions(maxHeight, maxWidth)
+type ${capId}Position = ${boardPositions(maxBoard)
     .map(t => `"${t}"`)
     .join(" | ")};
 

--- a/modules/games/commands/helpers/analyze.ts
+++ b/modules/games/commands/helpers/analyze.ts
@@ -11,7 +11,8 @@ import {
   isAlgolEffectSetTurnVar,
   isAlgolEffectSetBattleVar,
   isAlgolEffectIncreaseTurnVar,
-  isAlgolEffectIncreaseBattleVar,, AlgolBoardAnon
+  isAlgolEffectIncreaseBattleVar,
+  AlgolBoardAnon,
 } from "../../../types";
 import {
   boardPositions,
@@ -42,7 +43,10 @@ export default async function analyze(def: FullDefAnon | string) {
     }),
     { maxHeight: 0, maxWidth: 0 }
   );
-  const maxBoard = { height: maxHeight, width: maxWidth } as unknown as AlgolBoardAnon
+  const maxBoard = ({
+    height: maxHeight,
+    width: maxWidth,
+  } as unknown) as AlgolBoardAnon;
   const terrains = Array.from(
     new Set(
       Object.values(boards).flatMap(board => Object.keys(board.terrain || {}))

--- a/modules/games/definitions/gowiththefloe/_types.ts
+++ b/modules/games/definitions/gowiththefloe/_types.ts
@@ -4,7 +4,7 @@ import { CommonLayer, FullDef, AlgolGameBlob } from "../../../types";
 type GowiththefloeBoardHeight = 8;
 type GowiththefloeBoardWidth = 8;
 
-type GowiththefloeTerrain = "water";
+type GowiththefloeTerrain = never;
 type GowiththefloeUnit = "seals" | "bears" | "holes";
 type GowiththefloeMark =
   | "selectunit"
@@ -43,12 +43,11 @@ type GowiththefloeArtifactLayer =
   | "jumptargets"
   | "canmove"
   | "cracks";
-type GowiththefloeTerrainLayer = "water" | "nowater";
+type GowiththefloeTerrainLayer = never;
 type GowiththefloeLayer =
   | CommonLayer
   | GowiththefloeUnitLayer
-  | GowiththefloeArtifactLayer
-  | GowiththefloeTerrainLayer;
+  | GowiththefloeArtifactLayer;
 type GowiththefloeBattlePos = never;
 type GowiththefloeBattleVar = never;
 type GowiththefloeTurnPos = never;

--- a/modules/games/definitions/gowiththefloe/boards.ts
+++ b/modules/games/definitions/gowiththefloe/boards.ts
@@ -8,23 +8,21 @@ const gowiththefloeBoardBook: GowiththefloeDefinition["boards"] = {
   basic: {
     height: 8,
     width: 8,
-    terrain: {
-      water: [
-        "a1",
-        "a2",
-        "a7",
-        "a8",
-        "b1",
-        "b8",
-        "g1",
-        "g8",
-        "h1",
-        "h2",
-        "h7",
-        "h8"
-      ]
-    }
-  }
+    holes: [
+      "a1",
+      "a2",
+      "a7",
+      "a8",
+      "b1",
+      "b8",
+      "g1",
+      "g8",
+      "h1",
+      "h2",
+      "h7",
+      "h8",
+    ],
+  },
 };
 
 export default gowiththefloeBoardBook;

--- a/modules/games/definitions/gowiththefloe/generators.ts
+++ b/modules/games/definitions/gowiththefloe/generators.ts
@@ -11,15 +11,15 @@ const gowiththefloeGenerators: GowiththefloeDefinition["generators"] = {
     dirs: "rose",
     start: "selectunit",
     ifover: "seals",
-    draw: { neighbours: { tolayer: "eattargets" } }
+    draw: { neighbours: { tolayer: "eattargets" } },
   },
   findmovetargets: {
     type: "walker",
     dirs: "rose",
     start: "selectunit",
     max: 2,
-    blocks: { union: ["seals", "bears", "water", "holes"] },
-    draw: { steps: { tolayer: "movetargets", include: { dir: ["dir"] } } }
+    blocks: "units",
+    draw: { steps: { tolayer: "movetargets", include: { dir: ["dir"] } } },
   },
   findjumptargets: {
     type: "walker",
@@ -27,35 +27,35 @@ const gowiththefloeGenerators: GowiththefloeDefinition["generators"] = {
     start: "selectunit",
     max: 1,
     steps: "holes",
-    blocks: { subtract: ["board", "units", "water", "holes"] },
+    blocks: { subtract: ["board", "units"] },
     stopPrio: ["outofbounds", "hitblock", "nomoresteps", "reachedmax"],
     draw: {
       block: {
         condition: { same: [["walklength"], 1] },
-        tolayer: "jumptargets"
-      }
-    }
+        tolayer: "jumptargets",
+      },
+    },
   },
   findsealsmoves: {
     type: "walker",
     dirs: "rose",
     starts: "seals",
     max: 2,
-    count: { subtract: ["nowater", "holes"] },
+    count: { subtract: ["board", "holes"] },
     draw: {
       start: {
         condition: { morethan: [["totalcount"], 0] },
-        tolayer: "canmove"
-      }
-    }
+        tolayer: "canmove",
+      },
+    },
   },
   findcracks: {
     type: "walker",
     start: "selectmovetarget",
     dir: { reldir: [{ read: ["movetargets", "selectmovetarget", "dir"] }, 5] },
     blocks: { single: "selectunit" },
-    draw: { steps: { tolayer: "cracks" }, block: { tolayer: "cracks" } }
-  }
+    draw: { steps: { tolayer: "cracks" }, block: { tolayer: "cracks" } },
+  },
 };
 
 export default gowiththefloeGenerators;

--- a/modules/games/definitions/gowiththefloe/graphics.ts
+++ b/modules/games/definitions/gowiththefloe/graphics.ts
@@ -6,8 +6,8 @@
 import { GowiththefloeDefinition } from "./_types";
 
 const gowiththefloeGraphics: GowiththefloeDefinition["graphics"] = {
-  tiles: { water: "water" },
-  icons: { seals: "king", bears: "queen", holes: "pawn" }
+  tiles: {},
+  icons: { seals: "king", bears: "queen", holes: "pawn" },
 };
 
 export default gowiththefloeGraphics;

--- a/modules/games/definitions/kingsvalley/_types.ts
+++ b/modules/games/definitions/kingsvalley/_types.ts
@@ -4,7 +4,7 @@ import { CommonLayer, FullDef, AlgolGameBlob } from "../../../types";
 type KingsvalleyBoardHeight = 7;
 type KingsvalleyBoardWidth = 7;
 
-type KingsvalleyTerrain = "goal" | "water";
+type KingsvalleyTerrain = "goal";
 type KingsvalleyUnit = "soldiers" | "kings";
 type KingsvalleyMark = "selectunit" | "selectmovetarget";
 type KingsvalleyCommand = "slide";
@@ -25,7 +25,11 @@ type KingsvalleyUnitLayer =
   | "neutralkings";
 type KingsvalleyGenerator = "findtrappedkings" | "findmovetargets";
 type KingsvalleyArtifactLayer = "enemytrappedkings" | "movetargets";
-type KingsvalleyTerrainLayer = "goal" | "water" | "nogoal" | "nowater";
+type KingsvalleyTerrainLayer =
+  | "goal"
+  | "neutralgoal"
+  | "nogoal"
+  | "noneutralgoal";
 type KingsvalleyLayer =
   | CommonLayer
   | KingsvalleyUnitLayer

--- a/modules/games/definitions/kingsvalley/boards.ts
+++ b/modules/games/definitions/kingsvalley/boards.ts
@@ -10,15 +10,14 @@ const kingsvalleyBoardBook: KingsvalleyDefinition["boards"] = {
     width: 5,
     terrain: {
       goal: { 0: ["c3"] },
-      water: [],
     },
   },
   labyrinth: {
     height: 7,
     width: 7,
+    holes: ["b3", "b5", "f3", "f5"],
     terrain: {
       goal: { 0: ["d4"] },
-      water: ["b3", "b5", "f3", "f5"],
     },
   },
 };

--- a/modules/games/definitions/kingsvalley/generators.ts
+++ b/modules/games/definitions/kingsvalley/generators.ts
@@ -26,7 +26,7 @@ const kingsvalleyGenerators: KingsvalleyDefinition["generators"] = {
     type: "walker",
     start: "selectunit",
     dirs: "rose",
-    blocks: { union: ["water", "units"] },
+    blocks: "units",
     draw: {
       last: {
         condition: {

--- a/modules/games/definitions/kingsvalley/graphics.ts
+++ b/modules/games/definitions/kingsvalley/graphics.ts
@@ -7,7 +7,7 @@ import { KingsvalleyDefinition } from "./_types";
 
 const kingsvalleyGraphics: KingsvalleyDefinition["graphics"] = {
   icons: { soldiers: "pawn", kings: "king" },
-  tiles: { goal: "playercolour", water: "water" },
+  tiles: { goal: "playercolour" },
 };
 
 export default kingsvalleyGraphics;

--- a/modules/games/definitions/stooges/_types.ts
+++ b/modules/games/definitions/stooges/_types.ts
@@ -4,7 +4,7 @@ import { CommonLayer, FullDef, AlgolGameBlob } from "../../../types";
 type StoogesBoardHeight = 5;
 type StoogesBoardWidth = 6;
 
-type StoogesTerrain = "corners";
+type StoogesTerrain = never;
 type StoogesUnit = "singles" | "doubles";
 type StoogesMark = "selectsingle" | "selectdouble" | "selectmovetarget";
 type StoogesCommand = "move" | "swap";
@@ -25,12 +25,8 @@ type StoogesUnitLayer =
   | "neutraldoubles";
 type StoogesGenerator = "findmovetargets" | "findwinline";
 type StoogesArtifactLayer = "movetargets" | "winline";
-type StoogesTerrainLayer = "corners" | "nocorners";
-type StoogesLayer =
-  | CommonLayer
-  | StoogesUnitLayer
-  | StoogesArtifactLayer
-  | StoogesTerrainLayer;
+type StoogesTerrainLayer = never;
+type StoogesLayer = CommonLayer | StoogesUnitLayer | StoogesArtifactLayer;
 type StoogesBattlePos = "lastswap";
 type StoogesBattleVar = "doubleswap" | "lastswap" | "lastswap";
 type StoogesTurnPos = never;

--- a/modules/games/definitions/stooges/boards.ts
+++ b/modules/games/definitions/stooges/boards.ts
@@ -8,22 +8,20 @@ const stoogesBoardBook: StoogesDefinition["boards"] = {
   basic: {
     height: 5,
     width: 6,
-    terrain: {
-      corners: [
-        "a1",
-        "a2",
-        "b1",
-        "a4",
-        "a5",
-        "b5",
-        "e1",
-        "f1",
-        "f2",
-        "e5",
-        "f4",
-        "f5",
-      ],
-    },
+    holes: [
+      "a1",
+      "a2",
+      "b1",
+      "a4",
+      "a5",
+      "b5",
+      "e1",
+      "f1",
+      "f2",
+      "e5",
+      "f4",
+      "f5",
+    ],
   },
 };
 

--- a/modules/games/definitions/stooges/graphics.ts
+++ b/modules/games/definitions/stooges/graphics.ts
@@ -10,9 +10,7 @@ const stoogesGraphics: StoogesDefinition["graphics"] = {
     singles: "pawn",
     doubles: "rook",
   },
-  tiles: {
-    corners: "castle",
-  },
+  tiles: {},
 };
 
 export default stoogesGraphics;

--- a/modules/graphics/render/renderTilesAndIcons.ts
+++ b/modules/graphics/render/renderTilesAndIcons.ts
@@ -1,4 +1,4 @@
-import { coords2pos, terrainLayers } from "../../common";
+import { boardHoles, coords2pos, terrainLayers } from "../../common";
 import { allTiles, colours, svgPicSide, allMarks, allIcons } from "../sprites";
 import { tileAtPos } from "./tileAtPos";
 import {
@@ -33,6 +33,7 @@ export function renderTilesAndIcons(opts: RenderTilesAndIconsOpts) {
   } = opts;
   const { height, width } = board;
   const layers = terrainLayers(board);
+  const holes = boardHoles(board);
 
   const spritesPerPos = sprites.reduce(
     (memo, sprite) => ({
@@ -77,7 +78,7 @@ export function renderTilesAndIcons(opts: RenderTilesAndIconsOpts) {
     ) {
       let drawX = col * side;
       const pos = coords2pos({ x: col, y: row });
-      let tile = tileAtPos(layers, tileMap, pos);
+      let tile = holes.includes(pos) ? "hole" : tileAtPos(layers, tileMap, pos);
       let isDark = !((col + (row % 2)) % 2);
       if (!(tile === "empty" && !isDark)) {
         const id = tile + (isDark ? "Dark" : "");

--- a/modules/graphics/render/renderTilesAndIcons.ts
+++ b/modules/graphics/render/renderTilesAndIcons.ts
@@ -31,8 +31,8 @@ export function renderTilesAndIcons(opts: RenderTilesAndIconsOpts) {
     sprites = [],
     definitionStrategy,
   } = opts;
-  const { height, width, terrain } = board;
-  const layers = terrainLayers(height, width, terrain!);
+  const { height, width } = board;
+  const layers = terrainLayers(board);
 
   const spritesPerPos = sprites.reduce(
     (memo, sprite) => ({

--- a/modules/graphics/render/tileAtPos.ts
+++ b/modules/graphics/render/tileAtPos.ts
@@ -5,7 +5,7 @@ export function tileAtPos(
   tilemap: FullDefAnon["graphics"]["tiles"],
   pos: string
 ) {
-  const found = Object.keys(tilemap).find(name => layers[name][pos]);
+  const found = Object.keys(tilemap).find(name => (layers[name] || {})[pos]);
   if (found) {
     const square = layers[found][pos];
     if (tilemap[found] === "playercolour") {
@@ -18,13 +18,4 @@ export function tileAtPos(
     }
   }
   return "empty";
-
-  return Object.keys(tilemap).reduce(function(mem, name) {
-    console.log(layers[name][pos]);
-    return layers[name][pos]
-      ? tilemap[name] === "playercolour"
-        ? `player${layers[name][pos].owner}base`
-        : (tilemap[name] as string)
-      : mem;
-  }, "empty");
 }

--- a/modules/graphics/sprites/tiles/hole-dark.ts
+++ b/modules/graphics/sprites/tiles/hole-dark.ts
@@ -1,0 +1,3 @@
+import { svgPicSide, colours } from "../_constants";
+
+export const holeDark = `<rect id="holeDark" width="${svgPicSide}" height="${svgPicSide}" fill="${colours.edge}" stroke="none" />`;

--- a/modules/graphics/sprites/tiles/hole.ts
+++ b/modules/graphics/sprites/tiles/hole.ts
@@ -1,0 +1,3 @@
+import { svgPicSide, colours } from "../_constants";
+
+export const hole = `<rect id="hole" width="${svgPicSide}" height="${svgPicSide}" fill="${colours.edge}" stroke="none" />`;

--- a/modules/graphics/sprites/tiles/index.ts
+++ b/modules/graphics/sprites/tiles/index.ts
@@ -9,6 +9,8 @@ export * from "./player2base-dark";
 export * from "./empty";
 export * from "./empty-dark";
 export * from "./water";
+export * from "./hole";
+export * from "./hole-dark";
 export * from "./water-dark";
 export * from "../_constants";
 
@@ -26,6 +28,8 @@ import { empty } from "./empty";
 import { emptyDark } from "./empty-dark";
 import { water } from "./water";
 import { waterDark } from "./water-dark";
+import { hole } from "./hole";
+import { holeDark } from "./hole-dark";
 
 export const allTiles = {
   castle,
@@ -42,4 +46,6 @@ export const allTiles = {
   emptyDark,
   water,
   waterDark,
+  hole,
+  holeDark,
 };

--- a/modules/logic/def2code/executors/section/board/index.ts
+++ b/modules/logic/def2code/executors/section/board/index.ts
@@ -8,8 +8,8 @@ export function executeSetBoard(
 ): string {
   const hasGrids = !!Object.values(gameDef.boards).find(b => b.grids);
   return `
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/allqueenschess.js
+++ b/modules/logic/generated/allqueenschess.js
@@ -36,8 +36,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/amazons.js
+++ b/modules/logic/generated/amazons.js
@@ -50,8 +50,8 @@ const game = {
   commands: { move: {}, fire: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/ambivalente.js
+++ b/modules/logic/generated/ambivalente.js
@@ -44,8 +44,8 @@ const game = {
   commands: { drop: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/aries.js
+++ b/modules/logic/generated/aries.js
@@ -40,8 +40,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/ataxx.js
+++ b/modules/logic/generated/ataxx.js
@@ -49,8 +49,8 @@ const game = {
   commands: { split: {}, jump: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/atrium.js
+++ b/modules/logic/generated/atrium.js
@@ -60,8 +60,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/bombardment.js
+++ b/modules/logic/generated/bombardment.js
@@ -44,8 +44,8 @@ const game = {
   commands: { detonate: {}, move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/breakthrough.js
+++ b/modules/logic/generated/breakthrough.js
@@ -37,8 +37,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/campaign.js
+++ b/modules/logic/generated/campaign.js
@@ -53,8 +53,8 @@ const game = {
   commands: { deploy: {}, jump: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/canthesardines.js
+++ b/modules/logic/generated/canthesardines.js
@@ -36,8 +36,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/chameleon.js
+++ b/modules/logic/generated/chameleon.js
@@ -53,8 +53,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/coffee.js
+++ b/modules/logic/generated/coffee.js
@@ -51,8 +51,8 @@ const game = {
   commands: { uphill: {}, downhill: {}, horisontal: {}, vertical: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/connectfour.js
+++ b/modules/logic/generated/connectfour.js
@@ -43,8 +43,8 @@ const game = {
   commands: { drop: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/crossings.js
+++ b/modules/logic/generated/crossings.js
@@ -60,8 +60,8 @@ const game = {
   commands: { step: {}, march: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/daggers.js
+++ b/modules/logic/generated/daggers.js
@@ -54,8 +54,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/descent.js
+++ b/modules/logic/generated/descent.js
@@ -83,8 +83,8 @@ const game = {
   commands: { move: {}, dig: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/desdemona.js
+++ b/modules/logic/generated/desdemona.js
@@ -73,8 +73,8 @@ const game = {
   commands: { move: {}, fire: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/duckpond.js
+++ b/modules/logic/generated/duckpond.js
@@ -36,8 +36,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/duplo.js
+++ b/modules/logic/generated/duplo.js
@@ -50,8 +50,8 @@ const game = {
   commands: { deploy: {}, expand: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/erdoslatino.js
+++ b/modules/logic/generated/erdoslatino.js
@@ -89,8 +89,8 @@ const game = {
   commands: { place1: {}, place2: {}, place3: {}, place4: {}, place5: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/euclid.js
+++ b/modules/logic/generated/euclid.js
@@ -68,8 +68,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/gekitai.js
+++ b/modules/logic/generated/gekitai.js
@@ -41,8 +41,8 @@ const game = {
   commands: { drop: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/gogol.js
+++ b/modules/logic/generated/gogol.js
@@ -53,8 +53,8 @@ const game = {
   commands: { deploy: {}, move: {}, jump: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/gowiththefloe.js
+++ b/modules/logic/generated/gowiththefloe.js
@@ -167,12 +167,7 @@ const game = {
       };
       let UNITLAYERS = step.UNITLAYERS;
       {
-        let BLOCKS = {
-          ...UNITLAYERS.seals,
-          ...UNITLAYERS.bears,
-          ...TERRAIN1.water,
-          ...UNITLAYERS.holes
-        };
+        let BLOCKS = UNITLAYERS.units;
         for (let DIR of roseDirs) {
           let MAX = 2;
           let POS = MARKS.selectunit;
@@ -190,12 +185,7 @@ const game = {
       {
         let allowedsteps = UNITLAYERS.holes;
         let BLOCKS = Object.keys(BOARD.board)
-          .filter(
-            k =>
-              !UNITLAYERS.units.hasOwnProperty(k) &&
-              !TERRAIN1.water.hasOwnProperty(k) &&
-              !UNITLAYERS.holes.hasOwnProperty(k)
-          )
+          .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
           .reduce((m, k) => {
             m[k] = emptyObj;
             return m;
@@ -313,12 +303,7 @@ const game = {
       };
       let UNITLAYERS = step.UNITLAYERS;
       {
-        let BLOCKS = {
-          ...UNITLAYERS.seals,
-          ...UNITLAYERS.bears,
-          ...TERRAIN2.water,
-          ...UNITLAYERS.holes
-        };
+        let BLOCKS = UNITLAYERS.units;
         for (let DIR of roseDirs) {
           let MAX = 2;
           let POS = MARKS.selectunit;
@@ -336,12 +321,7 @@ const game = {
       {
         let allowedsteps = UNITLAYERS.holes;
         let BLOCKS = Object.keys(BOARD.board)
-          .filter(
-            k =>
-              !UNITLAYERS.units.hasOwnProperty(k) &&
-              !TERRAIN2.water.hasOwnProperty(k) &&
-              !UNITLAYERS.holes.hasOwnProperty(k)
-          )
+          .filter(k => !UNITLAYERS.units.hasOwnProperty(k))
           .reduce((m, k) => {
             m[k] = emptyObj;
             return m;
@@ -529,7 +509,7 @@ const game = {
           for (let DIR of roseDirs) {
             let MAX = 2;
             let POS = STARTPOS;
-            let walkpositionstocount = Object.keys(TERRAIN1.nowater)
+            let walkpositionstocount = Object.keys(BOARD.board)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
               .reduce((m, k) => {
                 m[k] = emptyObj;
@@ -628,7 +608,7 @@ const game = {
           for (let DIR of roseDirs) {
             let MAX = 2;
             let POS = STARTPOS;
-            let walkpositionstocount = Object.keys(TERRAIN1.nowater)
+            let walkpositionstocount = Object.keys(BOARD.board)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
               .reduce((m, k) => {
                 m[k] = emptyObj;
@@ -731,7 +711,7 @@ const game = {
           for (let DIR of roseDirs) {
             let MAX = 2;
             let POS = STARTPOS;
-            let walkpositionstocount = Object.keys(TERRAIN2.nowater)
+            let walkpositionstocount = Object.keys(BOARD.board)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
               .reduce((m, k) => {
                 m[k] = emptyObj;
@@ -831,7 +811,7 @@ const game = {
           for (let DIR of roseDirs) {
             let MAX = 2;
             let POS = STARTPOS;
-            let walkpositionstocount = Object.keys(TERRAIN2.nowater)
+            let walkpositionstocount = Object.keys(BOARD.board)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
               .reduce((m, k) => {
                 m[k] = emptyObj;
@@ -916,7 +896,7 @@ const game = {
           for (let DIR of roseDirs) {
             let MAX = 2;
             let POS = STARTPOS;
-            let walkpositionstocount = Object.keys(TERRAIN2.nowater)
+            let walkpositionstocount = Object.keys(BOARD.board)
               .filter(k => !UNITLAYERS.holes.hasOwnProperty(k))
               .reduce((m, k) => {
                 m[k] = emptyObj;

--- a/modules/logic/generated/gowiththefloe.js
+++ b/modules/logic/generated/gowiththefloe.js
@@ -70,8 +70,8 @@ const game = {
   commands: { move: {}, jump: {}, eat: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/hippolyta.js
+++ b/modules/logic/generated/hippolyta.js
@@ -46,8 +46,8 @@ const game = {
   commands: { fire: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/hobbes.js
+++ b/modules/logic/generated/hobbes.js
@@ -45,8 +45,8 @@ const game = {
   commands: { move: {}, push: {}, pull: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/jostle.js
+++ b/modules/logic/generated/jostle.js
@@ -50,8 +50,8 @@ const game = {
   commands: { jostle: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/kachitknight.js
+++ b/modules/logic/generated/kachitknight.js
@@ -90,8 +90,8 @@ const game = {
   commands: { step: {}, orthogonal: {}, diagonal: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/kickrun.js
+++ b/modules/logic/generated/kickrun.js
@@ -46,8 +46,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/kingsvalley.js
+++ b/modules/logic/generated/kingsvalley.js
@@ -156,7 +156,7 @@ const game = {
       };
       let UNITLAYERS = step.UNITLAYERS;
       {
-        let BLOCKS = { ...TERRAIN1.water, ...UNITLAYERS.units };
+        let BLOCKS = UNITLAYERS.units;
         let STARTPOS = MARKS.selectunit;
         for (let DIR of roseDirs) {
           let walkedsquares = [];
@@ -210,7 +210,7 @@ const game = {
       };
       let UNITLAYERS = step.UNITLAYERS;
       {
-        let BLOCKS = { ...TERRAIN2.water, ...UNITLAYERS.units };
+        let BLOCKS = UNITLAYERS.units;
         let STARTPOS = MARKS.selectunit;
         for (let DIR of roseDirs) {
           let walkedsquares = [];

--- a/modules/logic/generated/kingsvalley.js
+++ b/modules/logic/generated/kingsvalley.js
@@ -54,8 +54,8 @@ const game = {
   commands: { slide: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/krieg.js
+++ b/modules/logic/generated/krieg.js
@@ -54,8 +54,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/madbishops.js
+++ b/modules/logic/generated/madbishops.js
@@ -40,8 +40,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/momentum.js
+++ b/modules/logic/generated/momentum.js
@@ -44,8 +44,8 @@ const game = {
   commands: { pie: {}, drop: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/murusgallicus.js
+++ b/modules/logic/generated/murusgallicus.js
@@ -79,8 +79,8 @@ const game = {
   commands: { move: {}, crush: {}, sacrifice: {}, fire: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/neutron.js
+++ b/modules/logic/generated/neutron.js
@@ -55,8 +55,8 @@ const game = {
   commands: { slide: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/orthokon.js
+++ b/modules/logic/generated/orthokon.js
@@ -36,8 +36,8 @@ const game = {
   commands: { slide: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/sapos.js
+++ b/modules/logic/generated/sapos.js
@@ -43,8 +43,8 @@ const game = {
   commands: { hop: {}, jump: {}, spawn: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/scatter.js
+++ b/modules/logic/generated/scatter.js
@@ -64,8 +64,8 @@ const game = {
   commands: { move: {}, north: {}, east: {}, south: {}, west: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/serauqs.js
+++ b/modules/logic/generated/serauqs.js
@@ -46,8 +46,8 @@ const game = {
   commands: { promote: {}, move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/shoveoff.js
+++ b/modules/logic/generated/shoveoff.js
@@ -51,8 +51,8 @@ const game = {
   commands: { north: {}, south: {}, east: {}, west: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/speedsoccolot.js
+++ b/modules/logic/generated/speedsoccolot.js
@@ -59,8 +59,8 @@ const game = {
   commands: { run: {}, dribble: {}, kick: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/squava.js
+++ b/modules/logic/generated/squava.js
@@ -48,8 +48,8 @@ const game = {
   commands: { drop: {}, pie: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/stooges.js
+++ b/modules/logic/generated/stooges.js
@@ -54,8 +54,8 @@ const game = {
   commands: { move: {}, swap: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/threemusketeers.js
+++ b/modules/logic/generated/threemusketeers.js
@@ -58,8 +58,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/tobito.js
+++ b/modules/logic/generated/tobito.js
@@ -54,8 +54,8 @@ const game = {
   commands: { move: {}, relocate: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/trafficlights.js
+++ b/modules/logic/generated/trafficlights.js
@@ -64,8 +64,8 @@ const game = {
   commands: { deploy: {}, promote: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/transet.js
+++ b/modules/logic/generated/transet.js
@@ -60,8 +60,8 @@ const game = {
   commands: { move: {}, swap: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/tunneler.js
+++ b/modules/logic/generated/tunneler.js
@@ -64,8 +64,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/tyrannos.js
+++ b/modules/logic/generated/tyrannos.js
@@ -79,8 +79,8 @@ const game = {
   commands: { move: {}, attack: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/uglyduck.js
+++ b/modules/logic/generated/uglyduck.js
@@ -54,8 +54,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/uisge.js
+++ b/modules/logic/generated/uisge.js
@@ -58,8 +58,8 @@ const game = {
   commands: { jump: {}, step: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/yonmoque.js
+++ b/modules/logic/generated/yonmoque.js
@@ -62,8 +62,8 @@ const game = {
   commands: { drop: {}, move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/logic/generated/zonesh.js
+++ b/modules/logic/generated/zonesh.js
@@ -36,8 +36,8 @@ const game = {
   commands: { move: {} },
   iconMap: iconMapping,
   setBoard: board => {
-    TERRAIN1 = terrainLayers(board.height, board.width, board.terrain, 1);
-    TERRAIN2 = terrainLayers(board.height, board.width, board.terrain, 2);
+    TERRAIN1 = terrainLayers(board, 1);
+    TERRAIN2 = terrainLayers(board, 2);
     dimensions = { height: board.height, width: board.width };
     BOARD = boardLayers(dimensions);
     connections = boardConnections(board);

--- a/modules/types/gamedef/board/index.ts
+++ b/modules/types/gamedef/board/index.ts
@@ -6,6 +6,7 @@ import { TerrainDef } from "./terrain";
 import { AlgolGrid } from "./grid";
 import { AlgolOffset } from "./offset";
 import { AlgolGameBlobAnon } from "../../blob";
+import { AlgolEntity } from "../../primitives";
 
 export type AlgolBoard<Blob extends AlgolGameBlobAnon> = {
   height: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
@@ -14,6 +15,7 @@ export type AlgolBoard<Blob extends AlgolGameBlobAnon> = {
   offset?: AlgolOffset;
   terrain?: { [terrain in Blob["terrain"]]: TerrainDef<Blob> };
   grids?: { [name in Blob["grid"]]: AlgolGrid<number, number> }; // TODO - grid number safety?
+  holes?: AlgolEntity<Blob>[];
 };
 
 export type AlgolBoardAnon = AlgolBoard<AlgolGameBlobAnon>;


### PR DESCRIPTION
- [x] Make `terrainLayers` take entire board def
- [x] Make `boardPositions` take entire board def and exclude holes
- [x] Make `boardConnection` not link to holes (by tweaking `offsetPos`)
- [x] Update games that can be simplified with holes:
    - Go with the Floe
    - King's Valley
    - 3 Stooges

Fixes #216 