### PR TITLE
Fix news page meta image url

### DIFF
--- a/modules/content/commands/helpers/writeNews.ts
+++ b/modules/content/commands/helpers/writeNews.ts
@@ -64,14 +64,11 @@ export const writeNews = (id: string) => {
     created: \`${date}\`,
     updated: \`${yaml.updated || date}\`,
     preloads: ${JSON.stringify(preloads)},
-    mainImage: \`/images/news/${date}/${yaml.mainImage}\`,
+    mainImage: \`/images/news/${id}/${yaml.mainImage}\`,
     thumbnail: \`${yaml.thumbnail}\`,
 };
 `;
   writeFileSync(path.join(out, "listing.ts"), listing);
-  fs.copySync(
-    picSourcePath,
-    path.join(out, "pics")
-  )
+  fs.copySync(picSourcePath, path.join(out, "pics"));
   console.log("Wrote news", date);
 };

--- a/modules/content/material/news/news_2020_10_20/news.md
+++ b/modules/content/material/news/news_2020_10_20/news.md
@@ -2,7 +2,7 @@
 id: "news_2020_10_20"
 title: "2020-10-20 — Not alone"
 slug: "not_alone"
-blurb: "I am not alone!"
+blurb: "I am not alone anymore!"
 thumbnail: "eye_thumb.jpg"
 mainImage: "not_alone_logo_edge.jpg"
 updated: "2020-10-20"

--- a/modules/ui/src/components/PayloadArticlePage/PayloadArticlePage.make.tsx
+++ b/modules/ui/src/components/PayloadArticlePage/PayloadArticlePage.make.tsx
@@ -16,6 +16,7 @@ export const makePayloadArticlePage = (article: AlgolArticle) => {
     key: article.id,
     crumbs: [],
     me: {
+      id: article.id,
       title: article.title,
       desc: article.blurb,
       links: [],


### PR DESCRIPTION
Never noticed, but meta image url for news posts has been b0rked since the beginning.