### PR TITLE
Tweak start page buttons layout

### DIFF
--- a/modules/ui/src/components/TitlePage/TitlePage.css
+++ b/modules/ui/src/components/TitlePage/TitlePage.css
@@ -35,12 +35,16 @@
 
 .titlePageButtonContainer {
   display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  justify-content: space-between;
+  padding: 10px;
 }
 
-.titlePageButtonContainer > :not(:first-child) {
-  margin-top: 10px;
+@media (max-width: 430px) {
+  .titlePageButtonContainer {
+    padding: 4px;
+    margin-left: -10px;
+    margin-right: -10px;
+  }
 }
 
 .titlePageBoardContainer {


### PR DESCRIPTION
Made the start page buttons laid out horizontally.

![image](https://user-images.githubusercontent.com/719555/96878472-32c16480-147b-11eb-90f3-74c7ee14f08c.png)

For smaller screens, I decrease the padding quite a bit. See the image below. The pain point seems to be around <380px in screen width. 

![image](https://user-images.githubusercontent.com/719555/96878507-3c4acc80-147b-11eb-899a-9c66991949e0.png)

I'm thinking about a layout where the buttons are stacked on top centered horizontally, for screens smaller that his. @krawaller what do you think?

![image](https://user-images.githubusercontent.com/719555/96878999-c85cf400-147b-11eb-96b6-aed87488c2e6.png)
